### PR TITLE
Fix bug where CodeEditor would lose focus

### DIFF
--- a/waveform_editor/waveform_editor_gui.py
+++ b/waveform_editor/waveform_editor_gui.py
@@ -30,7 +30,6 @@ waveform:
 
 yaml_parser = YamlParser()
 
-
 initial_yaml_str = code_editor.value
 yaml_parser.parse_waveforms_from_string(initial_yaml_str)
 
@@ -43,7 +42,5 @@ def update_plot(value):
 
 
 hv_dynamic_map = hv.DynamicMap(pn.bind(update_plot, value=code_editor.param.value))
-
 layout = pn.Row(code_editor, hv_dynamic_map)
-
 layout.servable()


### PR DESCRIPTION
This fixes a bug introduced in #9 where the CodeEditor would lose focus when the figure was updated.