### PR TITLE
Fix initialization issue with single smooth tendency

### DIFF
--- a/tests/tendencies/test_smooth.py
+++ b/tests/tendencies/test_smooth.py
@@ -73,11 +73,23 @@ def test_prev_and_next_value():
     assert not tendency.annotations
 
 
-def test_generate():
+def test_get_value():
     """
     Check the generated values.
     """
     tendency = SmoothTendency(user_start=0, user_duration=1, user_from=3, user_to=6)
+    _, values = tendency.get_value()
+
+    assert values[0] == 3
+    assert values[-1] == 6
+    assert not tendency.annotations
+
+
+def test_get_value_no_start():
+    """
+    Check the generated values when no start is provided.
+    """
+    tendency = SmoothTendency(user_duration=8, user_from=3, user_to=6)
     _, values = tendency.get_value()
 
     assert values[0] == 3

--- a/waveform_editor/tendencies/smooth.py
+++ b/waveform_editor/tendencies/smooth.py
@@ -26,6 +26,7 @@ class SmoothTendency(BaseTendency):
         self.from_ = 0.0
         self.to = 0.0
         super().__init__(**kwargs)
+        self._update_values()
 
     def get_value(
         self, time: Optional[np.ndarray] = None
@@ -46,6 +47,12 @@ class SmoothTendency(BaseTendency):
             time = np.linspace(float(self.start), float(self.end), num_steps)
 
         values = self.spline(time)
+
+        if np.any(np.isnan(values)):
+            raise ValueError(
+                "A spline was generated at a time outside of its generated time range."
+            )
+
         return time, values
 
     def get_derivative(self, time: np.ndarray) -> np.ndarray:
@@ -110,6 +117,7 @@ class SmoothTendency(BaseTendency):
             [self.start, self.end],
             [from_, to],
             bc_type=((1, d_start), (1, d_end)),
+            extrapolate=False,
         )
 
         values_changed = (


### PR DESCRIPTION
This fixes a bug where the spline object of the smooth tendency was not properly updated after creation.

For example:
```yaml
waveform:
- {type: smooth, from: 0, to: 1, duration: 10}
```

Before:
![image](https://github.com/user-attachments/assets/dafec6a0-b0f0-47ae-8f20-f667ff021ff3)

After:
![image](https://github.com/user-attachments/assets/6d40602c-8a6b-49d7-a609-b9f4f2c5bd53)
