### PR TITLE
Give a warning if the repeated tendency has not completed a full cycle

### DIFF
--- a/tests/tendencies/test_repeat.py
+++ b/tests/tendencies/test_repeat.py
@@ -166,3 +166,12 @@ def test_filled(repeat_waveform):
     assert tendencies[2].base == 2
     assert tendencies[2].amplitude == -1
     assert tendencies[2].frequency == 0.25
+
+
+def test_too_short(repeat_waveform):
+    """Check for warning in annotations if repeated waveform has not completed a
+    single repetition."""
+    repeat_waveform["user_duration"] = 2
+    repeat_tendency = RepeatTendency(**repeat_waveform)
+    assert repeat_tendency.annotations
+    assert repeat_tendency.annotations[0]["type"] == "warning"

--- a/waveform_editor/tendencies/repeat.py
+++ b/waveform_editor/tendencies/repeat.py
@@ -18,13 +18,20 @@ class RepeatTendency(BaseTendency):
 
         self.waveform = Waveform(waveform=waveform, is_repeated=True)
         if not self.waveform.tendencies:
-            error_msg = "There are no tendencies in the repeated waveform."
+            error_msg = "There are no tendencies in the repeated waveform.\n"
             self.annotations.add(self.line_number, error_msg)
             return
 
         if self.waveform.tendencies[0].start != 0:
-            error_msg = "The starting point of the first repeated must be set to 0."
+            error_msg = "The starting point of the first repeated must be set to 0.\n"
             self.annotations.add(self.line_number, error_msg)
+
+        if self.duration < self.waveform.tendencies[-1].end:
+            error_msg = (
+                "The repeated tendency has not completed a single repetition.\n"
+                "Perhaps increase the duration of the repeated tendency?\n"
+            )
+            self.annotations.add(self.line_number, error_msg, is_warning=True)
 
         # Link the last tendency to the first tendency in the repeated waveform
         # We must lock the start to 0, otherwise it will take the start value of the


### PR DESCRIPTION
Should make it more clear why not all the repeated waveform is shown when the length of the repeated tendency is too short.