### PR TITLE
Fix bug where name of new waveform/group is not updated

### DIFF
--- a/waveform_editor/gui/selector/options_button_row.py
+++ b/waveform_editor/gui/selector/options_button_row.py
@@ -189,7 +189,7 @@ class OptionsButtonRow(Viewer):
     def _add_new_waveform(self, event):
         """Add the new waveform to CheckButtonGroup and update the
         WaveformConfiguration."""
-        name = self.new_waveform_panel.input.value
+        name = self.new_waveform_panel.input.value_input
 
         # Add empty waveform to YAML
         new_waveform = self.main_gui.config.parse_waveform(f"{name}: [{{}}]")
@@ -213,7 +213,7 @@ class OptionsButtonRow(Viewer):
 
     def _add_new_group(self, event):
         """Add the new group as a panel accordion and update the YAML."""
-        name = self.new_group_panel.input.value
+        name = self.new_group_panel.input.value_input
 
         # Create new group in configuration
         try:


### PR DESCRIPTION
Fixes a bug where adding a waveform or group could incorrectly trigger an "empty names not allowed" error, even when the [TextInput](https://panel.holoviz.org/reference/widgets/TextInput.html) was filled. The issue occurred because the add method was called before the TextInput.value field was properly updated. This replaces `value` with `value_input`, which is updated immediately after each keystroke.