### PR TITLE
Allow pressing enter to accept for TextInputForm

### DIFF
--- a/waveform_editor/gui/selector/text_input_form.py
+++ b/waveform_editor/gui/selector/text_input_form.py
@@ -8,21 +8,23 @@ class TextInputForm(Viewer):
 
     def __init__(self, text, is_visible=True, on_click=None):
         self.input = pn.widgets.TextInput(placeholder=text.strip())
+        if on_click:
+            self.input.param.watch(on_click, "enter_pressed")
         self.button = pn.widgets.ButtonIcon(
             icon="square-rounded-plus",
             size="30px",
             active_icon="square-rounded-plus-filled",
             description="Accept",
             margin=(10, 0, 0, 0),
+            on_click=on_click,
         )
-        if on_click:
-            self.button.on_click(on_click)
         self.cancel_button = pn.widgets.ButtonIcon(
             icon="circle-x",
             size="30px",
             active_icon="circle-x-filled",
             description="Cancel",
             margin=(10, 0, 0, 0),
+            on_click=self._on_select_cancel,
         )
         self.panel = pn.Row(
             self.input,
@@ -30,7 +32,6 @@ class TextInputForm(Viewer):
             self.cancel_button,
             visible=is_visible,
         )
-        self.cancel_button.on_click(self._on_select_cancel)
 
     def is_visible(self, is_visible):
         self.panel.visible = is_visible


### PR DESCRIPTION
This allows you to press enter instead of having to use the mouse to accept in `TextInputForm`. Example:

https://github.com/user-attachments/assets/b207ac3f-d875-4907-bc48-e93d5a4cab7d


