### PR TITLE
Improve startup times of the CLI

### DIFF
--- a/waveform_editor/cli.py
+++ b/waveform_editor/cli.py
@@ -4,13 +4,11 @@ from pathlib import Path
 
 import click
 import numpy as np
-import panel as pn
 from rich import console, traceback
 
 import waveform_editor
 from waveform_editor.configuration import WaveformConfiguration
 from waveform_editor.exporter import ConfigurationExporter
-from waveform_editor.gui.main import WaveformEditorGui
 from waveform_editor.util import times_from_csv
 
 logger = logging.getLogger(__name__)
@@ -65,6 +63,12 @@ def parse_linspace(ctx, param, value):
 @cli.command("gui")
 def launch_gui():
     """Launch the Waveform Editor GUI using Panel."""
+    # Use local imports to avoid loading the full GUI dependencies for the other CLI use
+    # cases:
+    import panel as pn
+
+    from waveform_editor.gui.main import WaveformEditorGui
+
     try:
         app = WaveformEditorGui()
         pn.serve(app)

--- a/waveform_editor/gui/main.py
+++ b/waveform_editor/gui/main.py
@@ -12,6 +12,8 @@ from waveform_editor.gui.selector.confirm_modal import ConfirmModal
 from waveform_editor.gui.selector.selector import WaveformSelector
 from waveform_editor.gui.start_up import StartUpPrompt
 
+# Note: these extension() calls take a couple of seconds
+# Please avoid importing this module unless actually starting the GUI
 hv.extension("plotly")
 pn.extension("plotly", "modal", "codeeditor", notifications=True)
 


### PR DESCRIPTION
Move slow GUI imports into the `gui` command to speed up the CLI for the other use cases.