### PR TITLE
Pypi publish workflow

### DIFF
--- a/.github/workflows/publish_pypi.yml
+++ b/.github/workflows/publish_pypi.yml
@@ -46,26 +46,3 @@ jobs:
     - name: Publish distribution to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1
 
-  ### TO BE REMOVED AFTER TESTS ###
-  publish-to-testpypi:
-    name: Publish Waveform-Editor distribution to TestPyPI
-    if: github.ref=='refs/heads/pypi-publish-workflow'  # only publish to TestPyPI on the feature branch
-    needs:
-    - build
-    runs-on: ubuntu-22.04
-    environment:
-      name: testpypi
-      url: https://test.pypi.org/p/waveform-editor
-    permissions:
-      id-token: write  # IMPORTANT: mandatory for trusted publishing
-    steps:
-    - name: Download all the dists
-      uses: actions/download-artifact@v4
-      with:
-        name: python-package-distributions
-        path: dist/
-    - name: Publish distribution to TestPyPI
-      uses: pypa/gh-action-pypi-publish@unstable/v1
-      with:
-        repository-url: https://test.pypi.org/legacy/
-        verbose: true

--- a/.github/workflows/publish_pypi.yml
+++ b/.github/workflows/publish_pypi.yml
@@ -1,0 +1,71 @@
+name: build-wheel-and-publish-pypi
+
+on:
+  push:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  build:
+    name: Build distribution
+    runs-on: ubuntu-22.04
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0 
+    - name: Set up Python
+      uses: actions/setup-python@v5
+    - name: Install pypa/build
+      run: >-
+        python3 -m pip install pip setuptools wheel build
+    - name: Build a binary wheel and a source tarball
+      run: python3 -m build .
+    - name: Store the distribution packages
+      uses: actions/upload-artifact@v4
+      with:
+        name: python-package-distributions
+        path: dist/
+        
+  publish-to-pypi:
+    name: Publish waveform-editor distribution to PyPI
+    if: startsWith(github.ref, 'refs/tags/') && github.repository_owner == 'iterorganization' # only publish to PyPI on tag pushes
+    needs:
+    - build
+    runs-on: ubuntu-22.04
+    environment:
+      name: pypi
+      url: https://pypi.org/p/waveform-editor
+    permissions:
+      id-token: write  # IMPORTANT: mandatory for trusted publishing
+    steps:
+    - name: Download all the dists
+      uses: actions/download-artifact@v4
+      with:
+        name: python-package-distributions
+        path: dist/
+    - name: Publish distribution to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+
+  ### TO BE REMOVED AFTER TESTS ###
+  publish-to-testpypi:
+    name: Publish Waveform-Editor distribution to TestPyPI
+    if: github.ref=='refs/heads/pypi-publish-workflow'  # only publish to TestPyPI on the feature branch
+    needs:
+    - build
+    runs-on: ubuntu-22.04
+    environment:
+      name: testpypi
+      url: https://test.pypi.org/p/waveform-editor
+    permissions:
+      id-token: write  # IMPORTANT: mandatory for trusted publishing
+    steps:
+    - name: Download all the dists
+      uses: actions/download-artifact@v4
+      with:
+        name: python-package-distributions
+        path: dist/
+    - name: Publish distribution to TestPyPI
+      uses: pypa/gh-action-pypi-publish@unstable/v1
+      with:
+        repository-url: https://test.pypi.org/legacy/
+        verbose: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "waveform-editor"
 description = "Python tool to create and edit 1D waveforms (time-varying signals)"
-readme = "README.rst"
+readme = {file = "README.md", content-type = "text/markdown"}
 authors = [
     {name = "Waveform Editor Developers"}
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,8 @@ include = ["waveform_editor*"]
 waveform-editor = "waveform_editor.cli:cli"
 
 [tool.setuptools_scm]
-# version_file = "waveform_editor/_version.py"
+#version_file = "waveform_editor/_version.py"
+local_scheme = "no-local-version"
 
 [tool.isort]
 line_length = 88


### PR DESCRIPTION
Was tested on test.pypi with this branch.
Result here https://test.pypi.org/project/waveform-editor/
Once merged, the workflow will be triggered when a new tag is pushed.