### PR TITLE
Show parse errors as notification in GUI

### DIFF
--- a/waveform_editor/gui/main.py
+++ b/waveform_editor/gui/main.py
@@ -88,7 +88,9 @@ class WaveformEditorGui:
 
         if self.config.load_error:
             pn.state.notifications.error(
-                f"YAML could not be loaded:\n{self.config.load_error}", duration=10000
+                "YAML could not be loaded:<br>"
+                + self.config.load_error.replace("\n", "<br>"),
+                duration=10000,
             )
             self.make_ui_visible(False)
             return

--- a/waveform_editor/yaml_parser.py
+++ b/waveform_editor/yaml_parser.py
@@ -86,6 +86,9 @@ class YamlParser:
 
                 root_group = self._recursive_load(group_content, group_name)
                 self.config.groups[group_name] = root_group
+
+            if self.parse_errors:
+                raise ValueError("\n".join(self.parse_errors))
         except Exception as e:
             self.config.clear()
             logger.warning("Got unexpected error: %s", e, exc_info=e)
@@ -181,7 +184,7 @@ class YamlParser:
 
             name = waveform_key.removeprefix("user_")
             waveform = waveform_yaml[waveform_key]
-            if not waveform:
+            if waveform is None:
                 raise yaml.YAMLError("Cannot have an empty waveform.")
             if not isinstance(waveform, (list, int, float)):
                 raise yaml.YAMLError(
@@ -198,5 +201,5 @@ class YamlParser:
             )
             return waveform
         except yaml.YAMLError as e:
-            self.parse_errors.append(e)
+            self.parse_errors.append(str(e))
             return Waveform()


### PR DESCRIPTION
This resolves #54.
- Parsing errors are shown as notification in the GUI.
- `waveform: 0` does not trigger parse error anymore.

For example, the following YAML now shows an error notification upon loading:
```yaml
globals:
  dd_version: 4.0.0
test:
  test/waveform1:
```
