### PR TITLE
Fix annotations

### DIFF
--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -17,7 +17,7 @@ def filled_annotations():
             "type": "error",
         },
         {
-            "row": line_numbers[1],
+            "row": line_numbers[1] - 1,  # account for annotation offset
             "column": 0,
             "text": test_messages[1],
             "type": "warning",

--- a/waveform_editor/annotations.py
+++ b/waveform_editor/annotations.py
@@ -28,6 +28,9 @@ class Annotations(UserList):
                 treated as an error.
         """
         error_type = "warning" if is_warning else "error"
+        # The key of the kv-pair is removed in the editor, so we account for this
+        if line_number > 0:
+            line_number -= 1
         self.append(
             {
                 "row": line_number,

--- a/waveform_editor/yaml_parser.py
+++ b/waveform_editor/yaml_parser.py
@@ -202,4 +202,6 @@ class YamlParser:
             return waveform
         except yaml.YAMLError as e:
             self.parse_errors.append(str(e))
-            return Waveform()
+            empty_waveform = Waveform()
+            empty_waveform.annotations.add_yaml_error(e)
+            return empty_waveform


### PR DESCRIPTION
This fixes two issues with the annotations:

- The key of the key-value pair is not shown anymore in the editor, so annotations now account for this.
- YAML errors now show up as annotation again.

https://github.com/user-attachments/assets/73389ac8-67ea-4edb-bf93-0e4db7168158

