### PR TITLE
Refactor: reduce spaghetti in waveform selection

### DIFF
--- a/waveform_editor/gui/main.py
+++ b/waveform_editor/gui/main.py
@@ -54,6 +54,7 @@ class WaveformEditorGui:
         self.plotter = WaveformPlotter()
         self.editor = WaveformEditor(self.plotter, self.config)
         self.selector = WaveformSelector(self)
+        self.selector.param.watch(self.update_plotted_waveforms, "selection")
         self.tabs = pn.Tabs(
             ("View Waveforms", self.plotter),
             ("Edit Waveforms", pn.Row(self.editor, self.plotter)),
@@ -78,6 +79,12 @@ class WaveformEditorGui:
         )
         self.template.sidebar.append(sidebar_column)
 
+    def update_plotted_waveforms(self, _):
+        """Update plotter.plotted_waveforms whenever the selector.selection changes."""
+        self.plotter.plotted_waveforms = {
+            waveform: self.config[waveform] for waveform in self.selector.selection
+        }
+
     def load_yaml(self, event):
         """Load waveform configuration from a YAML file.
 
@@ -101,7 +108,7 @@ class WaveformEditorGui:
         self.make_ui_visible(True)
 
         # Create tree structure in sidebar based on waveform groups in YAML
-        self.selector.create_waveform_selector_ui()
+        self.selector.refresh()
 
         if self.start_up.file_input.filename:
             new_filename = self.start_up.file_input.filename.replace(
@@ -120,7 +127,7 @@ class WaveformEditorGui:
         self.file_download.visible = is_visible
         self.export_button.visible = is_visible
         self.start_up.visible = not is_visible
-        self.selector.ui_selector.visible = is_visible
+        self.selector.visible = is_visible
 
     def save_yaml(self):
         """Generate and return the YAML file as a BytesIO object"""

--- a/waveform_editor/gui/selector/selection_group.py
+++ b/waveform_editor/gui/selector/selection_group.py
@@ -1,0 +1,122 @@
+from typing import TYPE_CHECKING, Union
+
+import panel as pn
+from panel.viewable import Viewer
+
+from waveform_editor.configuration import WaveformConfiguration
+from waveform_editor.group import WaveformGroup
+from waveform_editor.gui.selector.options_button_row import OptionsButtonRow
+
+if TYPE_CHECKING:
+    from waveform_editor.gui.selector.selector import WaveformSelector
+
+
+class SelectionGroup(Viewer):
+    """User Interface for selecting waveforms in a single waveform group"""
+
+    def __init__(
+        self,
+        selector: "WaveformSelector",
+        group: Union[WaveformConfiguration, WaveformGroup],
+        path: list[str],
+    ) -> None:
+        name = getattr(group, "name", "")
+        super().__init__(name=name)
+
+        self.selector = selector
+        self.group = group
+        self.path = path
+        self.is_root = not path
+
+        # Waveform selector
+        if self.is_root:  # We have no waveforms
+            self.waveform_selector = None
+            self.has_waveforms = False
+        else:
+            self.waveform_selector = pn.widgets.CheckButtonGroup(
+                value=[],
+                options=list(group.waveforms.keys()),
+                button_type="primary",
+                button_style="outline",
+                sizing_mode="stretch_width",
+                orientation="vertical",
+                stylesheets=["button {text-align: left!important;}"],
+            )
+            self.waveform_selector.param.watch(self.selector.on_select, "value")
+            self.selector.param.watch(self.sync_waveforms, "selection")
+            # Reactive expression which is True if there are waveforms in this group:
+            self.has_waveforms = self.waveform_selector.param.options.rx.bool()
+
+        self.button_row = OptionsButtonRow(selector.main_gui, self)
+        # Sub-groups
+        self.selection_groups = {
+            group.name: SelectionGroup(self.selector, group, self.path + [group.name])
+            for group in self.group.groups.values()
+        }
+        self.accordion = pn.Accordion(
+            *self.selection_groups.values(),
+            sizing_mode="stretch_width",
+        )
+
+        # Create container
+        if self.is_root:
+            elems = [self.button_row, self.accordion]
+        else:
+            elems = [self.button_row, self.waveform_selector, self.accordion]
+        self.panel = pn.Column(*elems, sizing_mode="stretch_both", name=name)
+
+    def sync_waveforms(self, event=None):
+        """Update waveform selector options and selected values"""
+        new_waveforms = list(self.group.waveforms.keys())
+        self.waveform_selector.options = new_waveforms
+        self.waveform_selector.value = [
+            val for val in new_waveforms if val in self.selector.selection
+        ]
+
+    def add_group(self, group: WaveformGroup) -> None:
+        """Add a sub-group to this UI element."""
+        group_ui = SelectionGroup(self.selector, group, self.path + [group.name])
+        self.selection_groups[group.name] = group_ui
+        self.accordion.append(group_ui)
+        # Auto-expand new group. N.B. active list must be replaced to take effect:
+        new_index = len(self.accordion.objects) - 1
+        self.accordion.active = self.accordion.active + [new_index]
+
+    def remove_group(self, group: str) -> None:
+        """Remove a group from this UI element"""
+        # Find index of the group UI:
+        for index, group_ui in enumerate(self.selection_groups.values()):  # noqa: B007
+            if group_ui.name == group:
+                break
+        # Remove from accordion
+        self.selection_groups.pop(group)
+        self.accordion.remove(self.accordion[index])
+        # Update active pane indices
+        self.accordion.active = [
+            num if num < index else num - 1
+            for num in self.accordion.active
+            if num != index
+        ]
+
+    def get_selection(self, recursive=False) -> list[str]:
+        """Get a list of the selected waveforms.
+
+        Args:
+            recursive: Include selection in sub-groups as well.
+        """
+        selection = [] if self.is_root else self.waveform_selector.value.copy()
+        if recursive:
+            for group_ui in self.selection_groups.values():
+                selection.extend(group_ui.get_selection(recursive))
+        return selection
+
+    def deselect_all(self, event=None) -> None:
+        """Deselect all waveforms."""
+        self.waveform_selector.value = []
+
+    def select_all(self, event=None) -> None:
+        """Select all waveforms."""
+        self.waveform_selector.value = self.waveform_selector.options.copy()
+
+    def __panel__(self):
+        return self.panel

--- a/waveform_editor/gui/selector/selector.py
+++ b/waveform_editor/gui/selector/selector.py
@@ -1,20 +1,33 @@
 import panel as pn
+import param
 from panel.viewable import Viewer
 
 from waveform_editor.gui.selector.confirm_modal import ConfirmModal
-from waveform_editor.gui.selector.options_button_row import OptionsButtonRow
+from waveform_editor.gui.selector.selection_group import SelectionGroup
 
 
 class WaveformSelector(Viewer):
     """Panel containing a dynamic waveform selection UI from YAML data."""
 
+    visible = param.Boolean()
+    selection = param.List(doc="List of selected waveform names")
+    multiselect = param.Boolean(True, doc="Allow selecting multiple waveforms")
+
     def __init__(self, main_gui):
+        super().__init__()
         self.main_gui = main_gui
         self.config = self.main_gui.config
+
+        # FIXME: we should be able to remove these
         self.plotter = self.main_gui.plotter
         self.editor = self.main_gui.editor
+
         self.confirm_modal = ConfirmModal()
-        self.ui_selector = pn.Accordion(sizing_mode="stretch_width")
+        self.selection_group = SelectionGroup(self, self.config, [])
+        self.panel = pn.Column(
+            self.selection_group, self.confirm_modal, visible=self.param.visible
+        )
+
         self.prev_selection = []
         self.ignore_tab_watcher = False
         self.ignore_select_watcher = False
@@ -23,18 +36,31 @@ class WaveformSelector(Viewer):
             "Leaving now will discard any changes you made to this waveform."
             "   \n\n**Are you sure you want to continue?**"
         )
-        self._create_root_button_row()
 
-    def create_waveform_selector_ui(self):
-        """Creates a UI for the selector sidebar, containing accordions for each
-        group in the config, option buttons, and CheckButtonGroups for the lists of
-        waveforms.
+    def refresh(self):
+        """Discard the current UI state and re-build from self.config.
+
+        Should be called after loading a new configuration.
         """
-        self.root_button_row.new_group_button.visible = True
-        self.ui_selector.objects = [
-            self.create_group_ui(group, [group.name], parent_accordion=self.ui_selector)
-            for group in self.config.groups.values()
-        ]
+        self.selection_group = SelectionGroup(self, self.config, [])
+        self.panel[0] = self.selection_group
+        self.selection = []
+
+    def remove_group(self, path: list[str]):
+        """Remove the UI element for the group at the specified path."""
+        self.main_gui.editor.stored_string = None  # FIXME: check if we can remove this
+
+        parent_group, group_ui = None, self.selection_group
+        for part in path:
+            parent_group, group_ui = group_ui, group_ui.selection_groups[part]
+
+        selection_to_delete = group_ui.get_selection(True)
+        parent_group.remove_group(path[-1])
+        del group_ui
+        if selection_to_delete:
+            self.selection = [
+                val for val in self.selection if val not in selection_to_delete
+            ]
 
     def on_tab_change(self, event):
         """Change selection behavior, depending on which tab is selected."""
@@ -49,13 +75,14 @@ class WaveformSelector(Viewer):
             self.confirm_tab_change()
 
     def confirm_tab_change(self):
-        self.deselect_all(ignore_watch=True)
         if self.main_gui.tabs.active == self.main_gui.EDIT_WAVEFORMS_TAB:
             self.plotter.has_legend = False
+            self.multiselect = False
+            # Only keep last selected waveform to edit:
+            self.confirm_on_select(self.selection[-1:])
         else:
             self.plotter.has_legend = True
-        self.plotter.plotted_waveforms = {}
-        self.editor.set_empty()
+            self.multiselect = True
 
     def cancel_tab_change(self):
         """Revert the selection Select the edit waveforms tab."""
@@ -63,55 +90,6 @@ class WaveformSelector(Viewer):
         self.ignore_tab_watcher = True
         self.main_gui.tabs.active = self.main_gui.EDIT_WAVEFORMS_TAB
         self.ignore_tab_watcher = False
-
-    def create_group_ui(self, group, path, parent_accordion=None):
-        """Recursively create a Panel UI structure from the YAML.
-
-        Args:
-            group: The group to add the new group to.
-            path: The path of the nested groups in the YAML data, as a list of strings.
-        """
-
-        # List of waveforms to select
-        waveforms = list(group.waveforms.keys())
-        check_buttons = pn.widgets.CheckButtonGroup(
-            value=[],
-            options=waveforms,
-            button_style="outline",
-            button_type="primary",
-            sizing_mode="stretch_width",
-            orientation="vertical",
-            stylesheets=["button {text-align: left!important;}"],
-        )
-        check_buttons.param.watch(self.on_select, "value")
-
-        # Create accordion to store the inner groups UI objects into
-        if group.groups:
-            inner_groups_ui = []
-            accordion = pn.Accordion()
-            for inner_group in group.groups.values():
-                new_path = path + [inner_group.name]
-                inner_groups_ui.append(
-                    self.create_group_ui(
-                        inner_group, new_path, parent_accordion=accordion
-                    )
-                )
-            accordion.objects = inner_groups_ui
-
-        parent_container = pn.Column(sizing_mode="stretch_width", name=group.name)
-
-        # Create row of options for each group
-        button_row = OptionsButtonRow(
-            self.main_gui, check_buttons, path, parent_accordion=parent_accordion
-        )
-
-        # Add buttons, waveform list and groups to UI column
-        ui_content = [button_row, check_buttons]
-        if group.groups:
-            ui_content.append(accordion)
-        parent_container.objects = ui_content
-
-        return parent_container
 
     def on_select(self, event):
         """Handles the selection and deselection of waveforms in the check button
@@ -122,100 +100,48 @@ class WaveformSelector(Viewer):
         """
         if self.ignore_select_watcher:
             return
-        new_selection = event.new
-        old_selection = event.old
 
-        # Find which waveform was newly selected
-        newly_selected = {
-            key: self.config[key] for key in new_selection if key not in old_selection
-        }
-        deselected = [key for key in old_selection if key not in new_selection]
-        if self.main_gui.tabs.active == self.main_gui.EDIT_WAVEFORMS_TAB:
+        if self.multiselect:  # Just update all selected
+            self.selection = self.selection_group.get_selection(True)
+
+        else:  # Check which one is new and deselect anything else
+            new_selection = [name for name in event.new if name not in event.old]
+            assert len(new_selection) <= 1
+
             if self.editor.has_changed():
                 self.confirm_modal.show(
                     self.warning_message,
-                    on_confirm=lambda: self.confirm_on_select(newly_selected),
-                    on_cancel=lambda: self.deselect_all(
-                        include=self.prev_selection, ignore_watch=True
-                    ),
+                    on_confirm=lambda: self.confirm_on_select(new_selection),
+                    on_cancel=self.cancel_on_select,
                 )
-                return
-            self.confirm_on_select(newly_selected)
+            else:
+                self.confirm_on_select(new_selection)
 
-        self.update_plotter(newly_selected, deselected)
-
-    def update_plotter(self, newly_selected, deselected):
-        for key in deselected:
-            if key in self.plotter.plotted_waveforms:
-                del self.plotter.plotted_waveforms[key]
-
-        for key, value in newly_selected.items():
-            self.plotter.plotted_waveforms[key] = value
-
-        self.plotter.param.trigger("plotted_waveforms")
-
-    def confirm_on_select(self, newly_selected):
+    def confirm_on_select(self, new_selection):
         """Only allow for a single waveform to be selected. All waveforms except for
         the newly selected waveform will be deselected.
 
         Args:
             newly_selected: The newly selected waveform.
         """
-        self.plotter.plotted_waveforms = {}
-        if newly_selected:
-            newly_selected_key = list(newly_selected.keys())[0]
-            self.deselect_all(exclude=newly_selected_key, ignore_watch=True)
-
+        self.ignore_select_watcher = True
+        self.selection = new_selection
+        self.ignore_select_watcher = False
+        # Update editor:
+        if new_selection:
+            newly_selected_key = new_selection[0]
             # Update code editor with the selected value
-            waveform = newly_selected[newly_selected_key]
+            waveform = self.config[newly_selected_key]
             self.editor.set_value(waveform.get_yaml_string(), waveform.name)
-            if len(newly_selected) != 1:
-                raise ValueError("Expected only a single new waveform to be selected.")
-            self.prev_selection = next(iter(newly_selected))
         else:
             self.editor.set_empty()
 
-    def deselect_all(self, exclude=None, ignore_watch=False, include=None):
-        """Deselect all options in all CheckButtonGroups. A waveform name can be
-        provided to be excluded from deselection.
-
-        Args:
-            exclude: The name of a waveform to exclude from deselection.
-        """
-        if ignore_watch:
-            self.ignore_select_watcher = True
-        self._deselect_checkbuttons(self.ui_selector, exclude, include)
-        if ignore_watch:
-            self.ignore_select_watcher = False
-
-    def _create_root_button_row(self):
-        """Creates a options button row at the root level of the selector groups."""
-        self.root_button_row = OptionsButtonRow(self.main_gui, None, [], visible=False)
-
-    def _deselect_checkbuttons(self, widget, exclude, include):
-        """Helper function to recursively find and deselect all CheckButtonGroup
-        widgets.
-
-        Args:
-            widget: The widget in which to deselect the checkbuttons.
-            exclude: The waveform to exclude from deselection.
-        """
-        if isinstance(widget, pn.widgets.CheckButtonGroup):
-            if exclude in widget.value:
-                widget.value = [exclude]
-            else:
-                widget.value = []
-
-            if include in widget.options and include not in widget.value:
-                widget.value.append(include)
-            widget.param.trigger("value")
-        elif isinstance(widget, (pn.Column, pn.Accordion)):
-            for child in widget:
-                # Skip select/deselect buttons row
-                if isinstance(widget, pn.Row):
-                    continue
-                self._deselect_checkbuttons(child, exclude, include)
+    def cancel_on_select(self):
+        """Don't change selection"""
+        self.ignore_select_watcher = True
+        self.param.trigger("selection")
+        self.ignore_select_watcher = False
 
     def __panel__(self):
         """Returns the waveform selector UI component."""
-        return pn.Column(self.root_button_row, self.ui_selector, self.confirm_modal)
+        return self.panel

--- a/waveform_editor/gui/selector/text_input_form.py
+++ b/waveform_editor/gui/selector/text_input_form.py
@@ -24,7 +24,7 @@ class TextInputForm(Viewer):
             active_icon="circle-x-filled",
             description="Cancel",
             margin=(10, 0, 0, 0),
-            on_click=self._on_select_cancel,
+            on_click=self.cancel,
         )
         self.panel = pn.Row(
             self.input,
@@ -42,6 +42,6 @@ class TextInputForm(Viewer):
     def __panel__(self):
         return self.panel
 
-    def _on_select_cancel(self, event):
+    def cancel(self, event=None):
         self.panel.visible = False
         self.clear_input()

--- a/waveform_editor/gui/start_up.py
+++ b/waveform_editor/gui/start_up.py
@@ -41,7 +41,7 @@ class StartUpPrompt(Viewer):
         self.visible = False
         self.main_gui.file_download.filename = "new.yaml"
         self.main_gui.make_ui_visible(True)
-        self.main_gui.selector.create_waveform_selector_ui()
+        self.main_gui.selector.refresh()
 
     def is_visible(self, event):
         """Sets visibility of the start-up prompt."""


### PR DESCRIPTION
- Introduce new SelectionGroup, which handles UI logic for all waveforms in a single WaveformGroup
- Move all UI logic for creating and deleting waveforms and groups into SelectionGroup

Also introduces some fixes/features:
- Keep selection (if possible) when switching tabs
  - When going into edit mode, the last waveform is retained
- Keep selection when deleting waveforms/groups
- Update empty waveform to `- {}` instead of `[{}]`

Ideally we will move the tab change logic out of selector, but that's out of scope for this PR.