### PR TITLE
Refactor/isolate editor and selector

### DIFF
--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -3,7 +3,7 @@ import csv
 import numpy as np
 import pytest
 
-from waveform_editor.util import times_from_csv
+from waveform_editor.util import State, times_from_csv
 
 
 def test_times_from_csv_valid(tmp_path):
@@ -51,3 +51,25 @@ def test_times_from_csv_invalid_format(tmp_path):
 def test_times_from_csv_none():
     """Test calling times_from_csv with None."""
     assert times_from_csv(None) is None
+
+
+def test_state():
+    state = State()
+
+    assert bool(state) is False
+    with state:
+        assert bool(state) is True
+    assert bool(state) is False
+
+    # Test that state returns to False on exceptions
+    try:
+        with state:
+            assert bool(state) is True
+            1 / 0  # noqa
+    except ZeroDivisionError:
+        pass
+    assert bool(state) is False
+
+    # enter state twice is an error:
+    with pytest.raises(RuntimeError), state, state:
+        pass

--- a/waveform_editor/gui/editor.py
+++ b/waveform_editor/gui/editor.py
@@ -23,13 +23,16 @@ class WaveformEditor(Viewer):
 
         # Code editor UI
         self.error_alert = pn.pane.Alert()
+        # Show error alert when object is set:
         self.error_alert.visible = self.error_alert.param.object.rx.bool()
+
         self.code_editor = pn.widgets.CodeEditor(
             sizing_mode="stretch_both",
             language="yaml",
             readonly=self.param.waveform.rx.is_(None),
         )
         self.code_editor.param.watch(self.on_value_change, "value")
+
         save_button = pn.widgets.ButtonIcon(
             icon="device-floppy",
             size="30px",

--- a/waveform_editor/gui/editor.py
+++ b/waveform_editor/gui/editor.py
@@ -1,35 +1,62 @@
+from typing import Optional
+
 import panel as pn
+import param
 from panel.viewable import Viewer
+
+from waveform_editor.waveform import Waveform
 
 
 class WaveformEditor(Viewer):
     """A Panel interface for waveform editing."""
 
-    def __init__(self, main_gui):
-        self.main_gui = main_gui
-        self.config = self.main_gui.config
-        self.waveform = None
+    waveform = param.ClassSelector(
+        class_=Waveform,
+        doc="Waveform currently being edited. Use `set_waveform` to change.",
+    )
 
+    def __init__(self, config):
+        super().__init__()
+        self.config = config
         # Contains the waveform text before any changes were made in the editor
         self.stored_string = None
 
         # Code editor UI
-        self.error_alert = pn.pane.Alert(visible=False)
+        self.error_alert = pn.pane.Alert()
+        self.error_alert.visible = self.error_alert.param.object.rx.bool()
         self.code_editor = pn.widgets.CodeEditor(
-            sizing_mode="stretch_both", language="yaml"
+            sizing_mode="stretch_both",
+            language="yaml",
+            readonly=self.param.waveform.rx.is_(None),
         )
         self.code_editor.param.watch(self.on_value_change, "value")
-        self.set_empty()
-
         save_button = pn.widgets.ButtonIcon(
             icon="device-floppy",
             size="30px",
             active_icon="check",
             description="Save waveform",
+            on_click=self.save_waveform,
         )
-        save_button.on_click(self.save_waveform)
-
         self.layout = pn.Column(save_button, self.code_editor, self.error_alert)
+
+        # Initialize empty
+        self.set_waveform(None)
+
+    def set_waveform(self, waveform: Optional[str]) -> None:
+        """Start editing a waveform.
+
+        Args:
+            waveform: Name of the waveform to edit. Can be set to None to disable the
+                editor.
+        """
+        self.waveform = None if waveform is None else self.config[waveform]
+        self.error_alert.object = ""  # clear any errors
+        if self.waveform is None:
+            self.code_editor.value = "Select a waveform to edit"
+            self.stored_string = None
+        else:
+            waveform_yaml = self.waveform.get_yaml_string()
+            self.stored_string = self.code_editor.value = waveform_yaml
 
     def on_value_change(self, event):
         """Update the plot based on the YAML editor input.
@@ -37,78 +64,49 @@ class WaveformEditor(Viewer):
         Args:
             event: Event containing the code editor value input.
         """
-        if not self.main_gui.plotter_edit.plotted_waveform:
+        if self.waveform is None:
             return
+
+        # Parse waveform YAML
         editor_text = event.new
-
-        # Fetch name of selected waveform
-        name = self.main_gui.plotter_edit.plotted_waveform.name
-
+        name = self.waveform.name
         # Merge code editor string with name into a single YAML string, ensure that
         # dashed lists are placed below the key containing the waveform name
         if editor_text.lstrip().startswith("- "):
             waveform_yaml = f"{name}:\n{editor_text}"
         else:
             waveform_yaml = f"{name}: {editor_text}"
-        self.waveform = self.config.parse_waveform(waveform_yaml)
-        annotations = self.waveform.annotations
+        waveform = self.config.parse_waveform(waveform_yaml)
 
+        # Handle exceptions:
+        annotations = waveform.annotations
         self.code_editor.annotations = list(annotations)
-
-        if self.config.parser.parse_errors:
+        if self.config.parser.parse_errors:  # Handle errors
             self.error_alert.object = (
                 "### The YAML did not parse correctly\n  "
                 f"{self.config.parser.parse_errors[0]}"
             )
             self.error_alert.alert_type = "danger"
-            self.error_alert.visible = True
-        elif self.code_editor.annotations:
-            self.error_alert.object = (
-                f"### There was an error in the YAML configuration\n{annotations}"
-            )
-            self.error_alert.alert_type = "warning"
-            self.error_alert.visible = True
-        else:
-            self.error_alert.visible = False
-
-        # Only update plot when there are no YAML errors
-        if not self.config.parser.parse_errors:
-            self.main_gui.plotter_edit.plotted_waveform = self.waveform
-
-    def set_empty(self):
-        """Set code editor value to empty value in read-only mode."""
-        self.code_editor.value = "Select a waveform to edit"
-        self.code_editor.readonly = True
-        self.error_alert.visible = False
-        self.stored_string = None
-
-    def set_value(self, value):
-        """Set code editor value to the given value and disable read-only mode.
-
-        Args:
-            value: The value to set the code editor's value to.
-        """
-        self.code_editor.value = value
-        self.stored_string = value
-        self.code_editor.readonly = False
+        else:  # No errors
+            if self.code_editor.annotations:  # Handle warnings
+                self.error_alert.object = (
+                    f"### There was an error in the YAML configuration\n{annotations}"
+                )
+                self.error_alert.alert_type = "warning"
+            else:
+                self.error_alert.object = ""  # Clear any previous errors or warnings
+            # There are no errors: update self.waveform
+            self.waveform = waveform
 
     def save_waveform(self, event=None):
-        """Store the waveform into the WaveformConfiguration at the location determined
-        by self.path."""
+        """Store the waveform into the WaveformConfiguration."""
         if self.error_alert.visible:
             pn.state.notifications.error("Cannot save YAML with errors.")
             return
 
-        if self.waveform.name in self.config.waveform_map:
-            self.config.replace_waveform(self.waveform)
-            # TODO: Sometimes notifications seem to not be shown, even when this is
-            # called, should be investigated
-            pn.state.notifications.success("Succesfully saved waveform!")
-            self.stored_string = self.code_editor.value
-        else:
-            pn.state.notifications.error(
-                f"Error: `{self.waveform.name}` not found in YAML"
-            )
+        self.config.replace_waveform(self.waveform)
+        self.stored_string = self.code_editor.value
+        pn.state.notifications.success("Succesfully saved waveform!")
 
     def has_changed(self):
         """Return whether the code editor value was changed from its stored value"""

--- a/waveform_editor/gui/main.py
+++ b/waveform_editor/gui/main.py
@@ -52,7 +52,8 @@ class WaveformEditorGui:
         self.modal = ConfirmModal()
         self.plotter_view = PlotterView()
         self.plotter_edit = PlotterEdit()
-        self.editor = WaveformEditor(self)
+        self.editor = WaveformEditor(self.config)
+        self.plotter_edit.plotted_waveform = self.editor.param.waveform
         self.selector = WaveformSelector(self)
         self.selector.param.watch(self.update_plotted_waveforms, "selection")
         self.tabs = pn.Tabs(
@@ -81,18 +82,14 @@ class WaveformEditorGui:
 
     def update_plotted_waveforms(self, _):
         """Update plotter.plotted_waveforms whenever the selector.selection changes."""
-        if self.tabs.active == self.VIEW_WAVEFORMS_TAB:
-            self.plotter_view.plotted_waveforms = {
-                waveform: self.config[waveform] for waveform in self.selector.selection
-            }
-        elif self.tabs.active == self.EDIT_WAVEFORMS_TAB:
-            if len(self.selector.selection) == 0:
-                self.plotter_edit.plotted_waveform = None
-            elif len(self.selector.selection) == 1:
-                waveform = self.selector.selection[0]
-                self.plotter_edit.plotted_waveform = self.config[waveform]
-            else:
-                raise ValueError("Cannot select more than 1 waveform in editor.")
+        self.plotter_view.plotted_waveforms = {
+            waveform: self.config[waveform] for waveform in self.selector.selection
+        }
+        if len(self.selector.selection) == 0:
+            self.editor.set_waveform(None)
+        else:
+            waveform = self.selector.selection[0]
+            self.editor.set_waveform(waveform)
 
     def load_yaml(self, event):
         """Load waveform configuration from a YAML file.
@@ -102,7 +99,6 @@ class WaveformEditorGui:
         """
 
         self.plotter_view.plotted_waveforms = {}
-        self.plotter_edit.plotted_waveform = None
         yaml_content = event.new.decode("utf-8")
         self.config.parser.load_yaml(yaml_content)
 

--- a/waveform_editor/gui/main.py
+++ b/waveform_editor/gui/main.py
@@ -129,7 +129,7 @@ class WaveformEditorGui(param.Parameterized):
                 on_confirm=self.update_selection,
                 on_cancel=self.revert_to_editor,
             )
-        elif not self.editor.has_changed():  # only update sele
+        else:
             self.update_selection()
 
     def update_selection(self):

--- a/waveform_editor/gui/plotter_edit.py
+++ b/waveform_editor/gui/plotter_edit.py
@@ -7,7 +7,7 @@ from waveform_editor.waveform import Waveform
 class PlotterEdit(PlotterBase):
     """Class to plot a single waveform in edit mode."""
 
-    plotted_waveform: Waveform = param.ClassSelector(class_=Waveform, allow_None=True)
+    plotted_waveform: Waveform = param.ClassSelector(class_=Waveform, allow_refs=True)
 
     def __init__(self, **params):
         super().__init__(**params)

--- a/waveform_editor/gui/plotter_edit.py
+++ b/waveform_editor/gui/plotter_edit.py
@@ -11,10 +11,10 @@ class PlotterEdit(PlotterBase):
 
     def __init__(self, **params):
         super().__init__(**params)
-        self.param.watch(self.update_plot, "plotted_waveform")
-        self.update_plot(None)
+        self.update_plot()
 
-    def update_plot(self, _):
+    @param.depends("plotted_waveform", watch=True)
+    def update_plot(self):
         """
         Generate curves for each selected waveform and combine them into a Holoviews
         Overlay object, and update the plot pane.

--- a/waveform_editor/gui/plotter_view.py
+++ b/waveform_editor/gui/plotter_view.py
@@ -11,10 +11,10 @@ class PlotterView(PlotterBase):
 
     def __init__(self, **params):
         super().__init__(**params)
-        self.param.watch(self.update_plot, "plotted_waveforms")
-        self.update_plot(None)
+        self.update_plot()
 
-    def update_plot(self, _):
+    @param.depends("plotted_waveforms", watch=True)
+    def update_plot(self):
         """
         Generate curves for each selected waveform and combine them into a Holoviews
         Overlay object, and update the plot pane.

--- a/waveform_editor/gui/selector/options_button_row.py
+++ b/waveform_editor/gui/selector/options_button_row.py
@@ -121,10 +121,10 @@ class OptionsButtonRow(Viewer):
 
     def _remove_waveforms(self):
         """Remove all selected waveforms in this SelectionGroup."""
-        self.main_gui.editor.stored_string = None
         for waveform_name in self.selection_group.get_selection():
             self.config.remove_waveform(waveform_name)
-        self.selection_group.sync_waveforms()
+        with self.selector.is_removing_waveform:  # Signal we're removing waveforms
+            self.selection_group.sync_waveforms()
 
     def _show_remove_group_modal(self, event):
         self.main_gui.modal.show(

--- a/waveform_editor/gui/selector/selector.py
+++ b/waveform_editor/gui/selector/selector.py
@@ -79,8 +79,6 @@ class WaveformSelector(Viewer):
             self.confirm_on_select(self.selection[-1:])
         else:
             self.multiselect = True
-            # ensure plot is updated when discarding changes:
-            self.main_gui.update_plotted_waveforms(None)
 
     def cancel_tab_change(self):
         """Revert the selection Select the edit waveforms tab."""
@@ -125,14 +123,6 @@ class WaveformSelector(Viewer):
         self.ignore_select_watcher = True
         self.selection = new_selection
         self.ignore_select_watcher = False
-        # Update editor:
-        if new_selection:
-            newly_selected_key = new_selection[0]
-            # Update code editor with the selected value
-            waveform = self.config[newly_selected_key]
-            self.editor.set_value(waveform.get_yaml_string())
-        else:
-            self.editor.set_empty()
 
     def cancel_on_select(self):
         """Don't change selection"""

--- a/waveform_editor/gui/selector/selector.py
+++ b/waveform_editor/gui/selector/selector.py
@@ -2,38 +2,34 @@ import panel as pn
 import param
 from panel.viewable import Viewer
 
-from waveform_editor.gui.selector.confirm_modal import ConfirmModal
 from waveform_editor.gui.selector.selection_group import SelectionGroup
+from waveform_editor.util import State
 
 
 class WaveformSelector(Viewer):
     """Panel containing a dynamic waveform selection UI from YAML data."""
 
     visible = param.Boolean()
-    selection = param.List(doc="List of selected waveform names")
-    multiselect = param.Boolean(True, doc="Allow selecting multiple waveforms")
+    selection = param.List(
+        doc="List of selected waveform names. Use `set_selection` to set.",
+    )
+    multiselect = param.Boolean(
+        True,
+        doc="Allow selecting multiple waveforms",
+        allow_refs=True,
+    )
 
     def __init__(self, main_gui):
         super().__init__()
-        self.main_gui = main_gui
-        self.config = self.main_gui.config
-        # FIXME: we should be able to remove this
-        self.editor = self.main_gui.editor
+        self.main_gui = main_gui  # options_button_row needs the modal from main_gui
+        self.config = main_gui.config
+        self.is_removing_waveform = State()
+        self._ignore_selection_change = State()
+        self.param.watch(self._multiselect_changed, "multiselect")
 
-        self.confirm_modal = ConfirmModal()
+        # UI
         self.selection_group = SelectionGroup(self, self.config, [])
-        self.panel = pn.Column(
-            self.selection_group, self.confirm_modal, visible=self.param.visible
-        )
-
-        self.prev_selection = []
-        self.ignore_tab_watcher = False
-        self.ignore_select_watcher = False
-        self.warning_message = (
-            "# **⚠️ Warning**  \nYou did not save your changes. "
-            "Leaving now will discard any changes you made to this waveform."
-            "   \n\n**Are you sure you want to continue?**"
-        )
+        self.panel = pn.Column(self.selection_group, visible=self.param.visible)
 
     def refresh(self):
         """Discard the current UI state and re-build from self.config.
@@ -44,10 +40,20 @@ class WaveformSelector(Viewer):
         self.panel[0] = self.selection_group
         self.selection = []
 
+    def _multiselect_changed(self, _):
+        if not self.multiselect:
+            # Keep at most one item of the current selection:
+            self.set_selection(self.selection[:1])
+
+    def set_selection(self, new_selection: list[str]):
+        """Update the active selection."""
+        with self._ignore_selection_change:  # Don't listen to the widget callbacks
+            if not self.multiselect:
+                assert len(new_selection) <= 1
+            self.selection = new_selection
+
     def remove_group(self, path: list[str]):
         """Remove the UI element for the group at the specified path."""
-        self.main_gui.editor.stored_string = None  # FIXME: check if we can remove this
-
         parent_group, group_ui = None, self.selection_group
         for part in path:
             parent_group, group_ui = group_ui, group_ui.selection_groups[part]
@@ -56,45 +62,18 @@ class WaveformSelector(Viewer):
         parent_group.remove_group(path[-1])
         del group_ui
         if selection_to_delete:
-            self.selection = [
-                val for val in self.selection if val not in selection_to_delete
-            ]
-
-    def on_tab_change(self, event):
-        """Change selection behavior, depending on which tab is selected."""
-        if event.new != self.main_gui.EDIT_WAVEFORMS_TAB and self.editor.has_changed():
-            self.confirm_modal.show(
-                self.warning_message,
-                on_confirm=self.confirm_tab_change,
-                on_cancel=self.cancel_tab_change,
-            )
-            return
-        if not self.ignore_tab_watcher:
-            self.confirm_tab_change()
-
-    def confirm_tab_change(self):
-        if self.main_gui.tabs.active == self.main_gui.EDIT_WAVEFORMS_TAB:
-            self.multiselect = False
-            # Only keep last selected waveform to edit:
-            self.confirm_on_select(self.selection[-1:])
-        else:
-            self.multiselect = True
-
-    def cancel_tab_change(self):
-        """Revert the selection Select the edit waveforms tab."""
-        # Ensure apply_tab_change is not called again through watcher
-        self.ignore_tab_watcher = True
-        self.main_gui.tabs.active = self.main_gui.EDIT_WAVEFORMS_TAB
-        self.ignore_tab_watcher = False
+            new_sel = [val for val in self.selection if val not in selection_to_delete]
+            with self.is_removing_waveform:  # Flag that we're removing waveforms
+                self.set_selection(new_sel)
 
     def on_select(self, event):
         """Handles the selection and deselection of waveforms in the check button
-        group.
+        groups.
 
         Args:
             event: list containing the new selection.
         """
-        if self.ignore_select_watcher:
+        if self._ignore_selection_change:
             return
 
         if self.multiselect:  # Just update all selected
@@ -103,32 +82,7 @@ class WaveformSelector(Viewer):
         else:  # Check which one is new and deselect anything else
             new_selection = [name for name in event.new if name not in event.old]
             assert len(new_selection) <= 1
-
-            if self.editor.has_changed():
-                self.confirm_modal.show(
-                    self.warning_message,
-                    on_confirm=lambda: self.confirm_on_select(new_selection),
-                    on_cancel=self.cancel_on_select,
-                )
-            else:
-                self.confirm_on_select(new_selection)
-
-    def confirm_on_select(self, new_selection):
-        """Only allow for a single waveform to be selected. All waveforms except for
-        the newly selected waveform will be deselected.
-
-        Args:
-            newly_selected: The newly selected waveform.
-        """
-        self.ignore_select_watcher = True
-        self.selection = new_selection
-        self.ignore_select_watcher = False
-
-    def cancel_on_select(self):
-        """Don't change selection"""
-        self.ignore_select_watcher = True
-        self.param.trigger("selection")
-        self.ignore_select_watcher = False
+            self.set_selection(new_selection)
 
     def __panel__(self):
         """Returns the waveform selector UI component."""

--- a/waveform_editor/gui/selector/selector.py
+++ b/waveform_editor/gui/selector/selector.py
@@ -9,7 +9,7 @@ from waveform_editor.util import State
 class WaveformSelector(Viewer):
     """Panel containing a dynamic waveform selection UI from YAML data."""
 
-    visible = param.Boolean()
+    visible = param.Boolean(allow_refs=True)
     selection = param.List(
         doc="List of selected waveform names. Use `set_selection` to set.",
     )
@@ -25,7 +25,6 @@ class WaveformSelector(Viewer):
         self.config = main_gui.config
         self.is_removing_waveform = State()
         self._ignore_selection_change = State()
-        self.param.watch(self._multiselect_changed, "multiselect")
 
         # UI
         self.selection_group = SelectionGroup(self, self.config, [])
@@ -40,9 +39,10 @@ class WaveformSelector(Viewer):
         self.panel[0] = self.selection_group
         self.selection = []
 
-    def _multiselect_changed(self, _):
+    @param.depends("multiselect", watch=True)
+    def _multiselect_changed(self):
+        """Update selection when multiselect True -> False: keep at most one item."""
         if not self.multiselect:
-            # Keep at most one item of the current selection:
             self.set_selection(self.selection[:1])
 
     def set_selection(self, new_selection: list[str]):

--- a/waveform_editor/gui/start_up.py
+++ b/waveform_editor/gui/start_up.py
@@ -10,10 +10,11 @@ class StartUpPrompt(Viewer):
     visible = param.Boolean(
         default=True,
         doc="The visibility of the start-up prompt.",
+        allow_refs=True,
     )
 
-    def __init__(self, main_gui):
-        super().__init__()
+    def __init__(self, main_gui, **params):
+        super().__init__(**params)
         self.main_gui = main_gui
         self.file_input = pn.widgets.FileInput(accept=".yaml")
         self.file_input.param.watch(self.main_gui.load_yaml, "value")
@@ -33,19 +34,15 @@ class StartUpPrompt(Viewer):
             self.file_input,
             self.or_text,
             self.create_new_yaml_button,
+            visible=self.param.visible,
         )
-        self.param.watch(self.is_visible, "visible")
 
     def _create_new(self, event):
         """Sets up the GUI to start from a new, empty yaml."""
         self.visible = False
         self.main_gui.file_download.filename = "new.yaml"
-        self.main_gui.make_ui_visible(True)
+        self.main_gui.show_startup_options = False
         self.main_gui.selector.refresh()
-
-    def is_visible(self, event):
-        """Sets visibility of the start-up prompt."""
-        self.panel.visible = self.visible
 
     def __panel__(self):
         return self.panel

--- a/waveform_editor/util.py
+++ b/waveform_editor/util.py
@@ -45,7 +45,7 @@ class State:
 
         ignore_clicks = State()
         def process(obj):
-            if skip_processing:
+            if ignore_clicks:
                 return
             ...
         widget = pn.widgets.Button(name="Process", on_click=process)

--- a/waveform_editor/util.py
+++ b/waveform_editor/util.py
@@ -36,3 +36,38 @@ def times_from_csv(source, from_file_path=True):
     # Convert string values to floats
     time_array = [float(value) for value in rows[0]]
     return np.array(time_array)
+
+
+class State:
+    """Simple state object to suppress declarative logic.
+
+    Example:
+
+        ignore_clicks = State()
+        def process(obj):
+            if skip_processing:
+                return
+            ...
+        widget = pn.widgets.Button(name="Process", on_click=process)
+
+        # Elsewhere we can use a with statement to temporarily ignore clicks:
+        with ignore_clicks:
+            # process will not do anything, even though the on_click triggers
+            widget.clicks = 0
+    """
+
+    def __init__(self):
+        self.state = False
+
+    def __bool__(self):
+        return self.state
+
+    def __enter__(self):
+        if self.state:
+            raise RuntimeError("Cannot enter context manager twice")
+        self.state = True
+
+    def __exit__(self, type, value, traceback):
+        if not self.state:
+            raise RuntimeError("Unexpected state")
+        self.state = False


### PR DESCRIPTION
Some code refactorings. Main goals were to make the `WaveformEditor` and `WaveformSelector` UI elements more independent from the rest of the GUI code.

- Move tab change & selection change logic from WaveformSelector to WaveformEditorGui, so the Selector no longer references outside classes
- Add a State object to temporarily alter behaviour of declaratively triggered methods
- Changing the edited waveform happens through the new "WaveformEditor.set_waveform" method, the Editor no longer references any outside classes
- Set up param references between WaveformEditor and PlotterEdit so this plotter will always show the waveform being edited in the Editor
- Add `show_startup_options` in the main gui, make visibilities dependent on this param instead of a dedicated `make_ui_visible` method
- Update StartUpPrompt to make better use of its `visible` property