### PR TITLE
Improve piecewise drag and drop functionality

### DIFF
--- a/waveform_editor/gui/plotter_edit.py
+++ b/waveform_editor/gui/plotter_edit.py
@@ -1,13 +1,15 @@
 from io import StringIO
 
 import holoviews as hv
+import numpy as np
 import panel as pn
 import param
-from holoviews import streams
+from holoviews import opts, streams
 from panel.viewable import Viewer
 from ruamel.yaml import YAML
 
 from waveform_editor.tendencies.piecewise import PiecewiseLinearTendency
+from waveform_editor.util import State
 from waveform_editor.waveform import Waveform
 
 
@@ -19,6 +21,10 @@ class PlotterEdit(Viewer):
     def __init__(self, editor, **params):
         super().__init__(**params)
         self.editor = editor
+
+        self._update_plot_from_drag = State()
+        self.pipe = streams.Pipe()
+
         self.pane = pn.pane.HoloViews(sizing_mode="stretch_both")
         # TODO: The y axis should show the units of the plotted waveform
         self.xlabel = "Time (s)"
@@ -27,84 +33,112 @@ class PlotterEdit(Viewer):
 
     @param.depends("plotted_waveform", watch=True)
     def update_plot(self):
-        """
-        Generate curves for each selected waveform and combine them into a Holoviews
-        Overlay object, and update the plot pane.
-        """
-        overlay = self.plot_waveform(self.plotted_waveform)
+        """Update the plot"""
+        if self._update_plot_from_drag:
+            return  # Skip update triggered from a drag-and-drop
 
-        self.pane.object = overlay
+        if self.plotted_waveform is None or not self.plotted_waveform.tendencies:
+            self.pane.object = hv.Curve(([], []), self.xlabel, self.ylabel)
+            return
 
-    def plot_waveform(self, waveform):
-        """
-        Store the tendencies of a waveform into a holoviews overlay. If the waveform
-        contains a piecewise linear tendency, enable the point draw tool.
+        # Find all piecewise linear tendencies
+        pwl_tendencies = [
+            tendency
+            for tendency in self.plotted_waveform.tendencies
+            if isinstance(tendency, PiecewiseLinearTendency)
+        ]
+        if not pwl_tendencies:
+            # No need for a CruveEdit stream, just show the whole waveform:
+            self.pane.object = self.main_curve()
 
-        Args:
-            waveform: The waveform to convert to a holoviews curve.
+        else:
+            # Create a single Curve, which is a stitched together version of all
+            # piecewise tendencies, and add a CurveEdit stream to it:
+            pwl_values = [tendency.get_value() for tendency in pwl_tendencies]
+            # Stitch tendencies into a single curve, separated by nan values:
+            stitched_time = [[np.nan]] * (2 * len(pwl_values) - 1)
+            stitched_values = [[np.nan]] * (2 * len(pwl_values) - 1)
+            stitched_time[::2] = [val[0] for val in pwl_values]
+            stitched_values[::2] = [val[1] for val in pwl_values]
+            stitched_time = np.concatenate(stitched_time)
+            stitched_values = np.concatenate(stitched_values)
 
-        Returns:
-            A Holoviews Curve object.
-        """
-
-        if waveform is None or not waveform.tendencies:
-            return hv.Curve(([], []), self.xlabel, self.ylabel)
-
-        curves = []
-        num_piecewise = 0
-        for tendency in waveform.tendencies:
-            times, values = tendency.get_value()
-            curve = hv.Curve(
-                (times, values), self.xlabel, self.ylabel, label=waveform.name
+            edit_curve = hv.Curve(
+                (stitched_time, stitched_values),
+                self.xlabel,
+                self.ylabel,
+                label="edit",
             )
+            curve_stream = streams.CurveEdit(
+                data=edit_curve.columns(),
+                source=edit_curve,
+                style={"color": "black", "size": 10},
+            )
+            curve_stream.add_subscriber(self.piecewise_click_and_drag)
 
-            curve = curve.opts(
-                line_width=2,
+            overlay = hv.DynamicMap(self.main_curve, streams=[self.pipe]) * edit_curve
+            self.pane.object = overlay.opts(
+                opts.Curve(line_width=2, color=hv.Cycle().values[0]),
+                opts.Curve("edit", alpha=0.2),
+            ).opts(
                 framewise=True,
                 show_legend=False,
-                color=hv.Cycle("Category20").values[0],
+                responsive=True,
             )
-            if isinstance(tendency, PiecewiseLinearTendency):
-                curve_stream = streams.CurveEdit(
-                    data=curve.columns(),
-                    source=curve,
-                    style={"color": "black", "size": 10},
-                )
-                curve_stream.add_subscriber(
-                    lambda data, idx=num_piecewise: self.piecewise_click_and_drag(
-                        data, idx
-                    )
-                )
-                num_piecewise += 1
-            curves.append(curve)
 
-        return hv.Overlay(curves)
+    def main_curve(self, **kwargs):
+        """Return a curve representing the whole waveform"""
+        return hv.Curve(self.plotted_waveform.get_value(), self.xlabel, self.ylabel)
 
-    def piecewise_click_and_drag(self, piecewise_data, piecewise_idx):
+    def piecewise_click_and_drag(self, data):
         """Updates a piecewise linear tendency in the code editor YAML time/value data.
+
         Args:
-            piecewise_data: Dictionary containing the new piecewise values.
-            piecewise_idx: Index of the selected piecewise linear tendency.
+            data: Dictionary containing the new piecewise values.
         """
         yaml = YAML()
         content = self.editor.code_editor.value
         stream = StringIO(content)
-        items = yaml.load(stream)
-
-        piecewise_indices = [
-            i for i, item in enumerate(items) if item.get("type") == "piecewise"
-        ]
-
-        if piecewise_idx >= len(piecewise_indices):
+        try:
+            items = yaml.load(stream)
+        except Exception:
+            pn.state.notifications.error("Please fix the waveform errors first")
             return
 
-        target_idx = piecewise_indices[piecewise_idx]
-        items[target_idx]["time"] = [float(x) for x in piecewise_data[self.xlabel]]
-        items[target_idx]["value"] = [float(y) for y in piecewise_data[self.ylabel]]
+        times = np.array(data[self.xlabel])
+        values = np.array(data[self.ylabel])
+        # Ensure times are monotonically increasing
+        if np.any(np.diff(times) <= 0):
+            for i in range(1, len(times)):
+                if times[i] <= times[i - 1]:
+                    times[i] = times[i - 1] * (1 + 1e-15)
+            # Coulnd't find an easy way to update the values of the CurveEdit, so just
+            # trigger a notification... Updating the CurveEdit should be possible
+            # though: the Table and CurveEdit in the documentation are linked as well:
+            # https://holoviews.org/reference/streams/bokeh/CurveEdit.html
+            pn.state.notifications.warning(
+                "Times must be increasing: clipping to previous time point."
+            )
+
+        data_idx = 0
+        nan_indices = [-1, *np.argwhere(np.isnan(times)).flatten(), None]
+
+        # Update data of the piecewise linear tendencies
+        for item in items:
+            if item.get("type") == "piecewise":
+                data_slice = slice(nan_indices[data_idx] + 1, nan_indices[data_idx + 1])
+                time = times[data_slice]
+                item["time"] = [float(x) for x in time]
+                item["value"] = [float(x) for x in values[data_slice]]
+                data_idx += 1
 
         output = StringIO()
         yaml.dump(items, output)
-        self.editor.code_editor.value = output.getvalue()
+        with self._update_plot_from_drag:
+            # Overwrite editor with updated data
+            self.editor.code_editor.value = output.getvalue()
+            # Trigger an update of self.main_curve
+            self.pipe.event()
 
     def __panel__(self):
-        return pn.Column(self.pane)
+        return self.pane

--- a/waveform_editor/gui/plotter_edit.py
+++ b/waveform_editor/gui/plotter_edit.py
@@ -48,7 +48,7 @@ class PlotterEdit(Viewer):
             if isinstance(tendency, PiecewiseLinearTendency)
         ]
         if not pwl_tendencies:
-            # No need for a CruveEdit stream, just show the whole waveform:
+            # No need for a CurveEdit stream, just show the whole waveform:
             self.pane.object = self.main_curve()
 
         else:


### PR DESCRIPTION
- There's only a single CurveEdit, even when there are multiple piecewise linear tendencies
- Plot doesn't get completely redrawn on drag-and-drop, keeping the CurveEdit active
- Handle invalid state of the editor (triggers notification)
- Ensure that the times array remains increasing