### PR TITLE
Refactor YAML loading

### DIFF
--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -189,7 +189,7 @@ def test_dump():
           - {type: smooth, duration: 25, to: 0}"""
     config = WaveformConfiguration()
     config.dd_version = "4.0.0"
-    config.parser.load_yaml(yaml_str)
+    config.load_yaml(yaml_str)
 
     new_waveform1_str = """
     ec_launchers/beam(1)/quantity:
@@ -207,7 +207,7 @@ def test_dump():
     dump = config.dump()
 
     new_config = WaveformConfiguration()
-    new_config.parser.load_yaml(dump)
+    new_config.load_yaml(dump)
     old_waveform = new_config["ec_launchers/beam(0)/power_launched"]
     new_waveform1 = new_config["ec_launchers/beam(1)/quantity"]
     new_waveform2 = new_config["ec_launchers/beam(2)/quantity"]
@@ -248,7 +248,7 @@ def test_dump_comments():
           # comment3
           - {duration: 25, to: 0}""")
     config = WaveformConfiguration()
-    config.parser.load_yaml(yaml_str)
+    config.load_yaml(yaml_str)
     dumped_yaml = config.dump()
     assert yaml_str.strip() == dumped_yaml.strip()
 
@@ -261,7 +261,7 @@ def test_load_yaml_duplicate():
       ec_launchers/beam(2)/phase/angle: 1.23
     """
     config = WaveformConfiguration()
-    config.parser.load_yaml(yaml_str)
+    config.load_yaml(yaml_str)
     assert config.load_error
     assert not config.groups
     assert not config.waveform_map
@@ -278,7 +278,7 @@ def test_load_yaml_globals():
       ec_launchers/beam(1)/phase/angle: 1e-3
     """
     config = WaveformConfiguration()
-    config.parser.load_yaml(yaml_str)
+    config.load_yaml(yaml_str)
     assert config.dd_version == "3.42.0"
     assert config.machine_description["ec_launchers"] == "imas:hdf5?path=testdb"
 
@@ -286,6 +286,6 @@ def test_load_yaml_globals():
     ec_launchers:
       ec_launchers/beam(1)/phase/angle: 1e-3
     """
-    config.parser.load_yaml(yaml_str)
+    config.load_yaml(yaml_str)
     assert not config.dd_version
     assert not config.machine_description

--- a/tests/test_exporter.py
+++ b/tests/test_exporter.py
@@ -610,7 +610,7 @@ def _export_ids(file_path, yaml_str, times):
     """Load the yaml string into a waveform config and export to an IDS."""
     config = WaveformConfiguration()
     config.dd_version = "4.0.0"
-    config.parser.load_yaml(yaml_str)
+    config.load_yaml(yaml_str)
     exporter = ConfigurationExporter(config, times)
     exporter.to_ids(file_path)
 

--- a/tests/test_yaml_parser.py
+++ b/tests/test_yaml_parser.py
@@ -220,12 +220,8 @@ def test_load_yaml_globals():
     globals:
       machine_description: imas:hdf5?path=test_md
     """
-    parser.load_yaml(yaml_str)
-    assert config.load_error
-    assert not config.groups
-    assert not config.waveform_map
-    assert config.dd_version is None
-    assert not config.machine_description
+    with pytest.raises(ValueError):
+        parser.load_yaml(yaml_str)
 
     yaml_str = """
     globals:

--- a/waveform_editor/cli.py
+++ b/waveform_editor/cli.py
@@ -213,7 +213,7 @@ def load_config(config: WaveformConfiguration, filepath: Path) -> None:
     logging.debug("Loading waveform configuration from %s", filepath)
 
     config.clear()
-    config.parser.load_yaml(filepath)
+    config.load_yaml(filepath)
 
     if config.load_error:  # Set when the YAML could not be parsed
         raise RuntimeError(f"Could not load waveforms: {config.load_error}")

--- a/waveform_editor/configuration.py
+++ b/waveform_editor/configuration.py
@@ -1,10 +1,13 @@
 import io
+import logging
 
 from ruamel.yaml import YAML
 from ruamel.yaml.comments import CommentedMap
 
 from waveform_editor.group import WaveformGroup
 from waveform_editor.yaml_parser import YamlParser
+
+logger = logging.getLogger(__name__)
 
 
 class WaveformConfiguration:
@@ -37,6 +40,15 @@ class WaveformConfiguration:
             if key in self.groups:
                 return self.groups[key]
             raise KeyError(f"{key!r} not found in groups")
+
+    def load_yaml(self, yaml_str):
+        self.clear()
+        try:
+            self.parser.load_yaml(yaml_str)
+        except Exception as e:
+            self.clear()
+            logger.warning("Got unexpected error: %s", e, exc_info=e)
+            self.load_error = str(e)
 
     def add_waveform(self, waveform, path):
         """Adds a waveform to a specific group in the configuration.

--- a/waveform_editor/configuration.py
+++ b/waveform_editor/configuration.py
@@ -42,6 +42,11 @@ class WaveformConfiguration:
             raise KeyError(f"{key!r} not found in groups")
 
     def load_yaml(self, yaml_str):
+        """Parses a YAML string and populates configuration.
+
+        Args:
+            yaml_str: The YAML string to load YAML for.
+        """
         self.clear()
         try:
             self.parser.load_yaml(yaml_str)

--- a/waveform_editor/gui/main.py
+++ b/waveform_editor/gui/main.py
@@ -157,7 +157,7 @@ class WaveformEditorGui(param.Parameterized):
 
         self.plotter_view.plotted_waveforms = {}
         yaml_content = event.new.decode("utf-8")
-        self.config.parser.load_yaml(yaml_content)
+        self.config.load_yaml(yaml_content)
 
         if self.config.load_error:
             pn.state.notifications.error(


### PR DESCRIPTION
This refactors how YAML file are loaded,
- Instead of having to go through the parser object, directly expose a `load_yaml` method in the configuration
- Use `add_waveform` and `add_group` methods when building configuration