### PR TITLE
Fix textinput requiring two click in export dialog

### DIFF
--- a/waveform_editor/gui/main.py
+++ b/waveform_editor/gui/main.py
@@ -98,7 +98,7 @@ class WaveformEditorGui(param.Parameterized):
         self.template = pn.template.FastListTemplate(
             title=f"Waveform Editor (v{waveform_editor.__version__})",
             main=self.tabs,
-            sidebar=sidebar,
+            sidebar=[sidebar],
             sidebar_width=400,
         )
 


### PR DESCRIPTION
This fixes the issue where textinputs in modals require two clicks to gain focus, using a solution that was proposed [here](https://discourse.holoviz.org/t/how-to-use-pn-modal-in-combination-with-a-template/8829). This fixes the issue for the `ExportModal`, but it does not solve it for modals which are triggered from a `ButtonIcon` object. This seems to be a bug in Panel, and is reported [here](https://github.com/holoviz/panel/issues/8015).