### PR TITLE
Add basic XML exporter for PCSSP

### DIFF
--- a/docs/source/cli.rst
+++ b/docs/source/cli.rst
@@ -139,7 +139,7 @@ This command reads the waveform definitions from the `YAML` file, evaluates them
 .. note::
     You must provide exactly one of `--linspace` or `--csv` for this command.
 
-export-xml
+export-pcssp-xml
 ----------
 
 Exports the waveform data to a PCSSP-compatible XML file.
@@ -148,7 +148,7 @@ Exports the waveform data to a PCSSP-compatible XML file.
 
 .. code-block:: bash
 
-   waveform-editor export-xml [OPTIONS] YAML OUTPUT_XML
+   waveform-editor export-pcssp-xml [OPTIONS] YAML OUTPUT_XML
 
 **Description:**
 

--- a/docs/source/cli.rst
+++ b/docs/source/cli.rst
@@ -139,5 +139,32 @@ This command reads the waveform definitions from the `YAML` file, evaluates them
 .. note::
     You must provide exactly one of `--linspace` or `--csv` for this command.
 
+export-xml
+----------
+
+Exports the waveform data to a PCSSP-compatible XML file.
+
+**Usage:**
+
+.. code-block:: bash
+
+   waveform-editor export-xml [OPTIONS] YAML OUTPUT_XML
+
+**Description:**
+
+This command reads waveform definitions from the given `YAML` file, evaluates them at the specified time points (via ``--linspace`` or ``--csv``), and exports the result to a PCSSP-compatible XML file at the path specified by ``OUTPUT_XML``. The XML format includes signal declarations and associated time-based trajectories.
+
+**Arguments:**
+
+*   ``YAML``: Path to the input waveform YAML configuration file.
+*   ``OUTPUT_XML``: Path to the file where the XML data will be saved. The parent directory will be created if it does not exist.
+
+**Options:**
+
+*   ``--linspace START,STOP,NUM``: Define time points using `numpy.linspace`. (See `Specifying Time Points for Export`_).
+*   ``--csv PATH``: Define time points using a CSV file. (See `Specifying Time Points for Export`_).
+
+.. note::
+    You must provide exactly one of `--linspace` or `--csv` for this command.
 
 .. _IMAS: https://imas.iter.org/

--- a/docs/source/cli.rst
+++ b/docs/source/cli.rst
@@ -140,7 +140,7 @@ This command reads the waveform definitions from the `YAML` file, evaluates them
     You must provide exactly one of `--linspace` or `--csv` for this command.
 
 export-pcssp-xml
-----------
+----------------
 
 Exports the waveform data to a PCSSP-compatible XML file.
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -100,11 +100,11 @@ def test_export_csv(runner, tmp_path, test_yaml_file, test_csv_file):
 
 def test_export_xml(runner, tmp_path, test_yaml_file, test_csv_file):
     csv_path, _ = test_csv_file
-    output_xml = tmp_path / "test.csv"
+    output_xml = tmp_path / "test.xml"
     result = runner.invoke(
         waveform_cli.cli,
         [
-            "export-xml",
+            "export-pcssp-xml",
             str(test_yaml_file),
             str(output_xml),
             "--csv",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -98,6 +98,23 @@ def test_export_csv(runner, tmp_path, test_yaml_file, test_csv_file):
     assert output_csv.exists()
 
 
+def test_export_xml(runner, tmp_path, test_yaml_file, test_csv_file):
+    csv_path, _ = test_csv_file
+    output_xml = tmp_path / "test.csv"
+    result = runner.invoke(
+        waveform_cli.cli,
+        [
+            "export-xml",
+            str(test_yaml_file),
+            str(output_xml),
+            "--csv",
+            str(csv_path),
+        ],
+    )
+    assert result.exit_code == 0
+    assert output_xml.exists()
+
+
 def test_export_csv_nested(runner, tmp_path, test_yaml_file, test_csv_file):
     csv_path, _ = test_csv_file
     output_csv = tmp_path / "subdir" / "subdir2" / "test.csv"

--- a/waveform_editor/cli.py
+++ b/waveform_editor/cli.py
@@ -152,6 +152,32 @@ def export_csv(yaml, output_csv, csv, linspace):
     exporter.to_csv(output_path)
 
 
+@cli.command("export-xml")
+@click.argument("yaml", type=click.Path(exists=True))
+@click.argument("output_xml", type=click.Path(exists=False))
+@click.option("--csv", type=click.Path(exists=False))
+@click.option("--linspace", callback=parse_linspace)
+def export_xml(yaml, output_xml, csv, linspace):
+    """Export waveform data to a PCSSP XML file.
+    \b
+    Arguments:
+      yaml: Path to the waveform YAML file.
+      output_xml: Path to output XML file.
+    \b
+    Options:
+      csv: CSV file containing a custom time array.
+      linspace: linspace containing start, stop and num values, e.g. 0,3,4
+
+    Note: The csv containing the time values should be formatted as a single row,
+    delimited by commas, For example: `1,2,3,4,5`.
+    """
+    if not csv and not linspace:
+        raise click.UsageError("Either --csv or --linspace must be provided")
+    exporter = create_exporter(yaml, csv, linspace)
+    output_path = Path(output_xml)
+    exporter.to_xml(output_path)
+
+
 @cli.command("actor")
 def actor():
     """Run the MUSCLE3 actor.

--- a/waveform_editor/cli.py
+++ b/waveform_editor/cli.py
@@ -109,6 +109,7 @@ def export_ids(yaml, uri, csv, linspace):
 @click.option("--linspace", callback=parse_linspace)
 def export_png(yaml, output_dir, csv, linspace):
     """Export waveform data to a PNG file.
+
     \b
     Arguments:
       yaml: Path to the waveform YAML file.
@@ -133,6 +134,7 @@ def export_png(yaml, output_dir, csv, linspace):
 @click.option("--linspace", callback=parse_linspace)
 def export_csv(yaml, output_csv, csv, linspace):
     """Export waveform data to a CSV file.
+
     \b
     Arguments:
       yaml: Path to the waveform YAML file.
@@ -152,13 +154,14 @@ def export_csv(yaml, output_csv, csv, linspace):
     exporter.to_csv(output_path)
 
 
-@cli.command("export-xml")
+@cli.command("export-pcssp-xml")
 @click.argument("yaml", type=click.Path(exists=True))
 @click.argument("output_xml", type=click.Path(exists=False))
 @click.option("--csv", type=click.Path(exists=False))
 @click.option("--linspace", callback=parse_linspace)
-def export_xml(yaml, output_xml, csv, linspace):
+def export_pcssp_xml(yaml, output_xml, csv, linspace):
     """Export waveform data to a PCSSP XML file.
+
     \b
     Arguments:
       yaml: Path to the waveform YAML file.
@@ -175,7 +178,7 @@ def export_xml(yaml, output_xml, csv, linspace):
         raise click.UsageError("Either --csv or --linspace must be provided")
     exporter = create_exporter(yaml, csv, linspace)
     output_path = Path(output_xml)
-    exporter.to_xml(output_path)
+    exporter.to_pcssp_xml(output_path)
 
 
 @cli.command("actor")

--- a/waveform_editor/exporter.py
+++ b/waveform_editor/exporter.py
@@ -7,7 +7,7 @@ import pandas as pd
 import plotly.graph_objects as go
 from imas.ids_path import IDSPath
 
-from waveform_editor.xml_exporter import XMLExporter
+from waveform_editor.pcssp_exporter import PCSSPExporter
 
 logger = logging.getLogger(__name__)
 logging.basicConfig(level=logging.INFO)
@@ -26,14 +26,14 @@ class ConfigurationExporter:
         if self.times is not None and not np.all(np.diff(self.times) > 0):
             raise ValueError("Time array must be in increasing order.")
 
-    def to_xml(self, file_path):
+    def to_pcssp_xml(self, file_path):
         """Export the configuration to a PCSSP XML file.
 
         Args:
             file_path: The file path to store the XML file to.
         """
-        xml_exporter = XMLExporter(self.config, self.times)
-        xml_exporter.export(file_path)
+        pcssp_exporter = PCSSPExporter(self.config, self.times)
+        pcssp_exporter.export(file_path)
         logger.info(
             f"Successfully exported waveform configuration to PCSSP XML at {file_path}."
         )

--- a/waveform_editor/exporter.py
+++ b/waveform_editor/exporter.py
@@ -7,6 +7,8 @@ import pandas as pd
 import plotly.graph_objects as go
 from imas.ids_path import IDSPath
 
+from waveform_editor.xml_exporter import XMLExporter
+
 logger = logging.getLogger(__name__)
 logging.basicConfig(level=logging.INFO)
 
@@ -23,6 +25,18 @@ class ConfigurationExporter:
         # times must be None, or in increasing order
         if self.times is not None and not np.all(np.diff(self.times) > 0):
             raise ValueError("Time array must be in increasing order.")
+
+    def to_xml(self, file_path):
+        """Export the configuration to a PCSSP XML file.
+
+        Args:
+            file_path: The file path to store the XML file to.
+        """
+        xml_exporter = XMLExporter(self.config, self.times)
+        xml_exporter.export(file_path)
+        logger.info(
+            f"Successfully exported waveform configuration to PCSSP XML at {file_path}."
+        )
 
     def to_ids(self, uri):
         """Export the waveforms in the configuration to IDSs.

--- a/waveform_editor/gui/io/file_exporter.py
+++ b/waveform_editor/gui/io/file_exporter.py
@@ -17,7 +17,7 @@ MANUALINPUT = "Manual"
 IDS_EXPORT = "IDS"
 CSV_EXPORT = "CSV"
 PNG_EXPORT = "PNG"
-XML_EXPORT = "XML"
+PCSSP_EXPORT = "PCSSP XML"
 DEFAULT = "Default"
 
 TIME_MODES = [LINSPACE, CSVFILE, MANUALINPUT]
@@ -29,7 +29,7 @@ class FileExporter(param.Parameterized):
 
     # Export type selection
     export_type = param.Selector(
-        objects=[IDS_EXPORT, CSV_EXPORT, PNG_EXPORT, XML_EXPORT]
+        objects=[IDS_EXPORT, CSV_EXPORT, PNG_EXPORT, PCSSP_EXPORT]
     )
     # IMAS URI or output path
     output = param.String()
@@ -124,7 +124,7 @@ class FileExporter(param.Parameterized):
             IDS_EXPORT: "e.g. imas:hdf5?path=testdb",
             PNG_EXPORT: "e.g. /path/to/export/pngs",
             CSV_EXPORT: "e.g. /path/to/export/output.csv",
-            XML_EXPORT: "e.g. /path/to/export/output.xml",
+            PCSSP_EXPORT: "e.g. /path/to/export/output.xml",
         }[self.export_type]
 
     @param.depends("export_type")
@@ -134,7 +134,7 @@ class FileExporter(param.Parameterized):
             IDS_EXPORT: "Please enter the output IMAS URI below:",
             PNG_EXPORT: "Please enter an output folder below:",
             CSV_EXPORT: "Please enter an output file below:",
-            XML_EXPORT: "Please enter an output file below:",
+            PCSSP_EXPORT: "Please enter an output file below:",
         }[self.export_type]
 
     @param.depends("export_type", watch=True)
@@ -233,8 +233,8 @@ class FileExporter(param.Parameterized):
                 exporter.to_png(Path(self.output))
             elif self.export_type == CSV_EXPORT:
                 exporter.to_csv(Path(self.output))
-            elif self.export_type == XML_EXPORT:
-                exporter.to_xml(Path(self.output))
+            elif self.export_type == PCSSP_EXPORT:
+                exporter.to_pcssp_xml(Path(self.output))
             self.progress.value = 100
             pn.state.notifications.success("Succesfully exported configuration")
             self._close()

--- a/waveform_editor/gui/io/file_exporter.py
+++ b/waveform_editor/gui/io/file_exporter.py
@@ -17,6 +17,7 @@ MANUALINPUT = "Manual"
 IDS_EXPORT = "IDS"
 CSV_EXPORT = "CSV"
 PNG_EXPORT = "PNG"
+XML_EXPORT = "XML"
 DEFAULT = "Default"
 
 TIME_MODES = [LINSPACE, CSVFILE, MANUALINPUT]
@@ -27,7 +28,9 @@ class FileExporter(param.Parameterized):
     """Handles the UI and logic for exporting waveform configurations."""
 
     # Export type selection
-    export_type = param.Selector(objects=[IDS_EXPORT, CSV_EXPORT, PNG_EXPORT])
+    export_type = param.Selector(
+        objects=[IDS_EXPORT, CSV_EXPORT, PNG_EXPORT, XML_EXPORT]
+    )
     # IMAS URI or output path
     output = param.String()
 
@@ -121,6 +124,7 @@ class FileExporter(param.Parameterized):
             IDS_EXPORT: "e.g. imas:hdf5?path=testdb",
             PNG_EXPORT: "e.g. /path/to/export/pngs",
             CSV_EXPORT: "e.g. /path/to/export/output.csv",
+            XML_EXPORT: "e.g. /path/to/export/output.xml",
         }[self.export_type]
 
     @param.depends("export_type")
@@ -130,6 +134,7 @@ class FileExporter(param.Parameterized):
             IDS_EXPORT: "Please enter the output IMAS URI below:",
             PNG_EXPORT: "Please enter an output folder below:",
             CSV_EXPORT: "Please enter an output file below:",
+            XML_EXPORT: "Please enter an output file below:",
         }[self.export_type]
 
     @param.depends("export_type", watch=True)
@@ -228,6 +233,8 @@ class FileExporter(param.Parameterized):
                 exporter.to_png(Path(self.output))
             elif self.export_type == CSV_EXPORT:
                 exporter.to_csv(Path(self.output))
+            elif self.export_type == XML_EXPORT:
+                exporter.to_xml(Path(self.output))
             self.progress.value = 100
             pn.state.notifications.success("Succesfully exported configuration")
             self._close()

--- a/waveform_editor/pcssp_exporter.py
+++ b/waveform_editor/pcssp_exporter.py
@@ -29,8 +29,12 @@ class PCSSPExporter:
         segment = ET.SubElement(
             segments,
             "SEGMENT",
-            # Watchdogs are unused, so left empty
-            {"name": "Waveform Editor", "id": "0", "wd_time": "", "wd_target": ""},
+            {
+                "name": "Waveform Editor",
+                "id": "0",
+                "wd_time": str(self.times[-1] - self.times[0]),
+                "wd_target": "EHTerm1",
+            },
         )
         self._add_trajectories(segment)
 

--- a/waveform_editor/pcssp_exporter.py
+++ b/waveform_editor/pcssp_exporter.py
@@ -32,7 +32,7 @@ class PCSSPExporter:
             {
                 "name": "Waveform Editor",
                 "id": "0",
-                "wd_time": str(self.times[-1] - self.times[0]),
+                "wd_time": str(self.times[-1]),
                 "wd_target": "EHTerm1",
             },
         )

--- a/waveform_editor/pcssp_exporter.py
+++ b/waveform_editor/pcssp_exporter.py
@@ -2,7 +2,11 @@ import xml.etree.ElementTree as ET
 from pathlib import Path
 
 
-class XMLExporter:
+class PCSSPExporter:
+    """Exports waveform configuration into PCSSP-compatible XML format. Information on
+    the PCSSP can be found here: https://github.com/iterorganization/PCSSP
+    """
+
     def __init__(self, config, times):
         self.config = config
         self.times = times

--- a/waveform_editor/xml_exporter.py
+++ b/waveform_editor/xml_exporter.py
@@ -1,0 +1,75 @@
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+
+class XMLExporter:
+    def __init__(self, config, times):
+        self.config = config
+        self.times = times
+
+    def export(self, file_path):
+        """Export configuration as an PCSSP XML file.
+
+        Args:
+            file_path: Destination file path for the XML output.
+        """
+        root = ET.Element("SCHEDULE")
+        declarations = ET.SubElement(root, "DECLARATIONS")
+        ET.SubElement(declarations, "PARAMETERS")
+        outputs = ET.SubElement(declarations, "OUTPUTS")
+
+        self._add_signals(outputs)
+
+        segments = ET.SubElement(root, "SEGMENTS")
+        # Only a single segment is currently supported
+        segment = ET.SubElement(
+            segments,
+            "SEGMENT",
+            # Watchdogs are unused, so left empty
+            {"name": "Waveform Editor", "id": "0", "wd_time": "", "wd_target": ""},
+        )
+        self._add_trajectories(segment)
+
+        tree = ET.ElementTree(root)
+        ET.indent(tree, space="  ", level=0)
+        Path(file_path).parent.mkdir(parents=True, exist_ok=True)
+        tree.write(file_path, encoding="utf-8", xml_declaration=True)
+
+    def _add_signals(self, parent):
+        """Add signals from waveforms to the given XML parent element.
+
+        Args:
+            parent: XML element to append the signal elements to.
+        """
+        for wf_name, group in self.config.waveform_map.items():
+            waveform = group[wf_name]
+            desc = "" if not waveform.metadata else waveform.metadata.documentation
+            signal = {
+                "name": waveform.name,
+                "signal_type": "Amplitude",
+                "type": "double",
+                "dimension": "1",
+                "description": desc,
+                "value": "0",
+            }
+            ET.SubElement(parent, "SIGNAL", signal)
+
+    def _add_trajectories(self, segment):
+        """Add trajectories to a XML segment based on the values of the waveforms.
+
+        Args:
+            segment: XML trajectories element to append trajectories to.
+        """
+        trajectories = ET.SubElement(segment, "SIGNALS_TRAJECTORIES")
+        for wf_name, group in self.config.waveform_map.items():
+            waveform = group[wf_name]
+            trajectory = ET.SubElement(
+                trajectories, "SIGNAL_TRAJECTORY", {"name": waveform.name}
+            )
+            ET.SubElement(trajectory, "ENTRY_RULE", {"is": "None"})
+            ET.SubElement(trajectory, "EXECUTION_RULE", {"is": "Linear"})
+            ET.SubElement(trajectory, "EXIT_RULE", {"is": "Last"})
+            reference = ET.SubElement(trajectory, "REFERENCE")
+            values = waveform.get_value(self.times)[1]
+            for t, v in zip(self.times, values):
+                ET.SubElement(reference, "POINT", {"time": str(t), "value": str(v)})


### PR DESCRIPTION
This adds support for exporting to a PCSSP XML file. 

Currently only very basic XML export is supported:
- Only a single segment
- All entry rules are set to `None`
- All exit rules are set to `Last`
- All execution rules are set to `Linear`
- Only signals with signal_type `Amplitude`, type `double` and dimension of 1 are supported