### PR TITLE
Fix constant constant waveforms not showing in plot

### DIFF
--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -360,4 +360,5 @@ def test_bounds(config):
     assert config.end == 10
 
     config.remove_group(path)
-    assert config.start == config.end == 0
+    assert config.start == 0
+    assert config.end == 1

--- a/tests/test_derived_waveform.py
+++ b/tests/test_derived_waveform.py
@@ -48,8 +48,9 @@ def test_const_waveform(const_waveform):
     assert waveform.yaml == const_value
     assert waveform.dependencies == set()
     assert waveform.get_yaml_string() == str(const_value)
+    time = np.linspace(0, 1, 1000)
     time_ret, value_ret = waveform.get_value()
-    assert np.all(time_ret == 0)
+    assert np.all(time_ret == time)
     assert np.all(value_ret == const_value)
     time = np.linspace(0, 100, num=101)
     time_ret, value_ret = waveform.get_value(time)

--- a/waveform_editor/configuration.py
+++ b/waveform_editor/configuration.py
@@ -15,6 +15,8 @@ logger = logging.getLogger(__name__)
 
 class WaveformConfiguration(param.Parameterized):
     has_changed = param.Boolean()
+    DEFAULT_START = 0
+    DEFAULT_END = 1
 
     def __init__(self):
         super().__init__()
@@ -28,8 +30,8 @@ class WaveformConfiguration(param.Parameterized):
         self.load_error = ""
         self.parser = YamlParser(self)
         self.dependency_graph = DependencyGraph()
-        self.start = 0
-        self.end = 0
+        self.start = self.DEFAULT_START
+        self.end = self.DEFAULT_END
 
     def __getitem__(self, key):
         """Retrieves a waveform or group by name/path.
@@ -318,8 +320,8 @@ class WaveformConfiguration(param.Parameterized):
                 min_start = min(min_start, waveform.tendencies[0].start)
                 max_end = max(max_end, waveform.tendencies[-1].end)
 
-        self.start = min_start if min_start != float("inf") else 0
-        self.end = max_end if max_end != float("-inf") else 0
+        self.start = min_start if min_start != float("inf") else self.DEFAULT_START
+        self.end = max_end if max_end != float("-inf") else self.DEFAULT_END
 
     def print(self, indent=0):
         """Prints the waveform configuration as a hierarchical tree.
@@ -338,6 +340,6 @@ class WaveformConfiguration(param.Parameterized):
         self.dd_version = None
         self.machine_description = {}
         self.load_error = ""
-        self.start = 0
-        self.end = 0
+        self.start = self.DEFAULT_START
+        self.end = self.DEFAULT_END
         self.has_changed = False


### PR DESCRIPTION
Fixes #84. Derived waveforms run from the `start` to the `end` of the configuration, which are both set to 0 by default. As constant values are now also derived waveforms, they also run from the `start` to the `end` of the configuration, which means they run from 0 to 0 if there are no other waveforms, which caused them to not display. To fix this, the default end of the configuration was set to 1 instead.