### PR TITLE
Allow to interrupt `waveform-editor gui` with Ctrl+C

### DIFF
--- a/waveform_editor/cli.py
+++ b/waveform_editor/cli.py
@@ -74,7 +74,7 @@ def launch_gui():
 
     try:
         app = WaveformEditorGui()
-        pn.serve(app)
+        pn.serve(app, threaded=True)
     except Exception as e:
         logger.error(f"Failed to launch GUI: {e}")
 

--- a/waveform_editor/gui/main.py
+++ b/waveform_editor/gui/main.py
@@ -194,5 +194,6 @@ class WaveformEditorGui(param.Parameterized):
         return self.template.servable()
 
 
-# Run the app
-WaveformEditorGui().serve()
+# Allow serving with `panel serve waveform_editor/gui/main.py`
+if "bokeh" in __name__:
+    WaveformEditorGui().serve()


### PR DESCRIPTION
And construct only a single WaveformEditorGui instance.