### PR TITLE
Do not show save waveform button if no waveform is selected

### DIFF
--- a/waveform_editor/gui/editor.py
+++ b/waveform_editor/gui/editor.py
@@ -21,6 +21,9 @@ class WaveformEditor(Viewer):
     )
     error_message = param.String(doc="Error or warning message to show in alert.")
     alert_type = param.String(default="danger")
+    has_changed = param.Boolean(
+        allow_refs=True, doc="Whether there are unsaved changes in the editor."
+    )
 
     def __init__(self, config):
         super().__init__()
@@ -47,7 +50,7 @@ class WaveformEditor(Viewer):
         save_button = pn.widgets.Button(
             name="Save Waveform",
             on_click=self.save_waveform,
-            disabled=self.has_changed.rx.not_() | has_error,
+            disabled=self.param.has_changed.rx.not_() | has_error,
         )
         self.layout = pn.Column(save_button, self.code_editor, self.error_alert)
 
@@ -93,7 +96,7 @@ class WaveformEditor(Viewer):
             waveform_yaml = f"{name}: {editor_text}"
         waveform = self.config.parse_waveform(waveform_yaml)
         self.handle_exceptions(waveform)
-        if not self.param.error_message.rx.bool().rx.value:
+        if not self.error_message:
             self.waveform = waveform
 
     def handle_exceptions(self, waveform):

--- a/waveform_editor/gui/editor.py
+++ b/waveform_editor/gui/editor.py
@@ -40,6 +40,7 @@ class WaveformEditor(Viewer):
             active_icon="check",
             description="Save waveform",
             on_click=self.save_waveform,
+            visible=self.param.waveform.rx.pipe(bool),
         )
         self.layout = pn.Column(save_button, self.code_editor, self.error_alert)
 

--- a/waveform_editor/gui/io/manager.py
+++ b/waveform_editor/gui/io/manager.py
@@ -57,7 +57,7 @@ class IOManager(Viewer):
         self.open_file = None
 
     def _confirm_unsaved_changes(self, action, message):
-        if self.main_gui.config.has_changed or self.main_gui.editor.has_changed():
+        if self.main_gui.config.has_changed or self.main_gui.editor.has_changed:
             message = f"""\
             ### ⚠️ **You have unsaved changes**
             {message}  

--- a/waveform_editor/gui/main.py
+++ b/waveform_editor/gui/main.py
@@ -114,7 +114,7 @@ class WaveformEditorGui(param.Parameterized):
             return  # ignore this event when we revert to the editor
         if (
             self.tabs.active == self.EDIT_WAVEFORMS_TAB
-            and self.editor.has_changed()
+            and self.editor.has_changed
             # Check if current waveform is being removed. The user already confirmed
             # they want to remove the waveform, so we don't ask again:
             and not self.selector.is_removing_waveform
@@ -131,7 +131,7 @@ class WaveformEditorGui(param.Parameterized):
         """Respond to a tab change"""
         if self._skip_editor_change_check:
             return  # ignore this event when we revert to the editor
-        if event.old == self.EDIT_WAVEFORMS_TAB and self.editor.has_changed():
+        if event.old == self.EDIT_WAVEFORMS_TAB and self.editor.has_changed:
             self.confirm_modal.show(
                 self.DISCARD_CHANGES_MESSAGE,
                 on_confirm=self.update_selection,


### PR DESCRIPTION
Previously, clicking the save waveform button would cause an error if no waveform was being edited. Now, the save button only appears when a waveform is actively being edited.