### PR TITLE
Set matplotlib backend to agg

### DIFF
--- a/waveform_editor/shape_editor/nice_plotter.py
+++ b/waveform_editor/shape_editor/nice_plotter.py
@@ -1,6 +1,7 @@
 import logging
 
 import holoviews as hv
+import matplotlib
 import matplotlib.pyplot as plt
 import panel as pn
 import param
@@ -9,6 +10,7 @@ from imas.ids_toplevel import IDSToplevel
 from waveform_editor.shape_editor.nice_integration import NiceIntegration
 from waveform_editor.shape_editor.plasma_shape import PlasmaShape
 
+matplotlib.use("Agg")
 logger = logging.getLogger(__name__)
 
 


### PR DESCRIPTION
Get rid of the user warning:
```
UserWarning: Starting a Matplotlib GUI outside of the main thread will likely fail.
  trics = plt.tricontour(r, z, psi, levels=levels)
```