### PR TITLE
Parameterisation of p' and ff' profiles

### DIFF
--- a/waveform_editor/gui/shape_editor.py
+++ b/waveform_editor/gui/shape_editor.py
@@ -31,7 +31,9 @@ class ShapeEditor(Viewer):
         self.plasma_shape = PlasmaShape()
         self.plasma_properties = PlasmaProperties()
         self.coil_currents = CoilCurrents()
-        self.nice_plotter = NicePlotter(self.communicator, self.plasma_shape)
+        self.nice_plotter = NicePlotter(
+            self.communicator, self.plasma_shape, self.plasma_properties
+        )
         self.nice_settings = settings.nice
 
         self.xml_params = (

--- a/waveform_editor/shape_editor/nice_plotter.py
+++ b/waveform_editor/shape_editor/nice_plotter.py
@@ -53,7 +53,6 @@ class NicePlotter(pn.viewable.Viewer):
             title="Equilibrium poloidal flux",
             xlabel="r [m]",
             ylabel="z [m]",
-            shared_axes=False,
         )
         self.CONTOUR_OPTS = hv.opts.Contours(
             cmap="viridis",

--- a/waveform_editor/shape_editor/nice_plotter.py
+++ b/waveform_editor/shape_editor/nice_plotter.py
@@ -61,6 +61,7 @@ class NicePlotter(pn.viewable.Viewer):
             title="Equilibrium poloidal flux",
             xlabel="r [m]",
             ylabel="z [m]",
+            shared_axes=False,
         )
         flux_map_elements = [
             hv.DynamicMap(self._plot_contours),
@@ -80,17 +81,18 @@ class NicePlotter(pn.viewable.Viewer):
         )
 
         profiles_plot = hv.DynamicMap(self._plot_profiles)
+        profiles_pane = pn.pane.HoloViews(
+            profiles_plot, width=self.WIDTH, height=self.HEIGHT
+        )
 
         self.panel = pn.Tabs(
             ("Flux Map", flux_map_pane),
-            ("Profiles", profiles_plot),
+            ("Profiles", profiles_pane),
         )
 
     @pn.depends("plasma_properties.profile_overlay")
     def _plot_profiles(self):
-        return self.plasma_properties.profile_overlay.opts(
-            width=self.WIDTH, height=self.HEIGHT, framewise=True
-        )
+        return self.plasma_properties.profile_overlay
 
     @pn.depends("plasma_shape.shape_curve", "show_desired_shape")
     def _plot_desired_shape(self):

--- a/waveform_editor/shape_editor/nice_plotter.py
+++ b/waveform_editor/shape_editor/nice_plotter.py
@@ -47,14 +47,6 @@ class NicePlotter(pn.viewable.Viewer):
             plasma_shape=plasma_shape,
             plasma_properties=plasma_properties,
         )
-        self.CONTOUR_OPTS = hv.opts.Contours(
-            cmap="viridis",
-            colorbar=True,
-            tools=["hover"],
-            colorbar_opts={"title": "Poloidal flux [Wb]"},
-            show_legend=False,
-        )
-
         self.DEFAULT_OPTS = hv.opts.Overlay(
             xlim=(0, 13),
             ylim=(-10, 10),
@@ -62,6 +54,13 @@ class NicePlotter(pn.viewable.Viewer):
             xlabel="r [m]",
             ylabel="z [m]",
             shared_axes=False,
+        )
+        self.CONTOUR_OPTS = hv.opts.Contours(
+            cmap="viridis",
+            colorbar=True,
+            tools=["hover"],
+            colorbar_opts={"title": "Poloidal flux [Wb]"},
+            show_legend=False,
         )
         flux_map_elements = [
             hv.DynamicMap(self._plot_contours),
@@ -87,7 +86,7 @@ class NicePlotter(pn.viewable.Viewer):
 
         self.panel = pn.Tabs(
             ("Flux Map", flux_map_pane),
-            ("Profiles", profiles_pane),
+            ("Plasma Profiles", profiles_pane),
         )
 
     @pn.depends("plasma_properties.profile_overlay")

--- a/waveform_editor/shape_editor/plasma_properties.py
+++ b/waveform_editor/shape_editor/plasma_properties.py
@@ -154,10 +154,11 @@ class PlasmaProperties(Viewer):
 
             return pn.Column(
                 *params[0:3],
-                pn.pane.Markdown("#### f_df_dpsi Parameterization", margin=0),
-                *params[3:6],
                 pn.pane.Markdown("#### dpressure_dpsi Parameterization", margin=0),
+                *params[3:6],
+                pn.pane.Markdown("#### f_df_dpsi Parameterization", margin=0),
                 *params[6:9],
+                margin=(5, 10),
             )
         elif self.input_mode == self.EQUILIBRIUM_INPUT:
             return pn.Param(self.input, show_name=False)

--- a/waveform_editor/shape_editor/plasma_properties.py
+++ b/waveform_editor/shape_editor/plasma_properties.py
@@ -20,24 +20,14 @@ class PlasmaPropertiesParams(param.Parameterized):
     b0 = param.Number(
         default=-5.3, softbounds=[-10, 10], label="Toroidal field at R0 [T]"
     )
-    dpressure_dpsi_alpha = param.Integer(
-        default=2, softbounds=[0, 10], label="dpressure_dpsi alpha"
-    )
+    dpressure_dpsi_alpha = param.Integer(default=2, softbounds=[0, 10], label="Alpha")
     dpressure_dpsi_beta = param.Number(
-        default=0.6, step=0.01, softbounds=[-10, 10], label="dpressure_dpsi beta"
+        default=0.6, step=0.01, softbounds=[-10, 10], label="Beta"
     )
-    dpressure_dpsi_gamma = param.Number(
-        default=1.4, softbounds=[0, 10], label="dpressure_dpsi gamma"
-    )
-    f_df_dpsi_alpha = param.Integer(
-        default=2, softbounds=[0, 10], label="f_df_dpsi alpha"
-    )
-    f_df_dpsi_beta = param.Number(
-        default=0.4, softbounds=[-10, 10], label="f_df_dpsi beta"
-    )
-    f_df_dpsi_gamma = param.Number(
-        default=1.4, softbounds=[0, 10], label="f_df_dpsi gamma"
-    )
+    dpressure_dpsi_gamma = param.Number(default=1.4, softbounds=[0, 10], label="Gamma")
+    f_df_dpsi_alpha = param.Integer(default=2, softbounds=[0, 10], label="Alpha")
+    f_df_dpsi_beta = param.Number(default=0.4, softbounds=[-10, 10], label="Beta")
+    f_df_dpsi_gamma = param.Number(default=1.4, softbounds=[0, 10], label="Gamma")
 
 
 class PlasmaProperties(Viewer):
@@ -161,11 +151,16 @@ class PlasmaProperties(Viewer):
             params = pn.Param(self.properties_params, show_name=False)
             params.mapping[param.Number] = FormattedEditableFloatSlider
             params.mapping[param.Integer] = pn.widgets.EditableIntSlider
-            params = pn.GridBox(*params, ncols=3)
-        elif self.input_mode == self.EQUILIBRIUM_INPUT:
-            params = pn.Param(self.input, show_name=False)
 
-        return params
+            return pn.Column(
+                *params[0:3],
+                pn.pane.Markdown("#### f_df_dpsi Parameterization", margin=0),
+                *params[3:6],
+                pn.pane.Markdown("#### dpressure_dpsi Parameterization", margin=0),
+                *params[6:9],
+            )
+        elif self.input_mode == self.EQUILIBRIUM_INPUT:
+            return pn.Param(self.input, show_name=False)
 
     def __panel__(self):
         return self.panel

--- a/waveform_editor/shape_editor/plasma_properties.py
+++ b/waveform_editor/shape_editor/plasma_properties.py
@@ -83,11 +83,12 @@ class PlasmaProperties(Viewer):
 
         if self.has_properties:
             p_prime_curve = hv.Curve(
-                (self.psi, self.dpressure_dpsi), "Poloidal flux", "p'"
+                (self.psi, self.dpressure_dpsi), kdims="Poloidal flux", label="p'"
             )
             ff_prime_curve = hv.Curve(
-                (self.psi, self.f_df_dpsi), "Poloidal flux", "ff'"
+                (self.psi, self.f_df_dpsi), kdims="Poloidal flux", label="ff'"
             )
+
             self.profile_overlay = (p_prime_curve * ff_prime_curve).opts(
                 hv.opts.Overlay(title="Plasma Profiles")
             )

--- a/waveform_editor/shape_editor/plasma_properties.py
+++ b/waveform_editor/shape_editor/plasma_properties.py
@@ -104,7 +104,7 @@ class PlasmaProperties(Viewer):
         self.ip = self.properties_params.ip
         self.r0 = self.properties_params.r0
         self.b0 = self.properties_params.b0
-        self.psi = np.linspace(-1, 0, 200)
+        self.psi = np.linspace(0, 1, 200)
         self.dpressure_dpsi = self._calculate_parametric_profile(
             self.psi,
             self.properties_params.dpressure_dpsi_alpha,
@@ -121,7 +121,7 @@ class PlasmaProperties(Viewer):
 
     def _calculate_parametric_profile(self, psi, alpha, beta, gamma):
         base = 1.0 - np.power(psi, alpha)
-        profile = beta * np.power(base, gamma)
+        profile = -1 * beta * np.power(base, gamma)
         return profile
 
     def _load_properties_from_ids(self):

--- a/waveform_editor/shape_editor/plasma_properties.py
+++ b/waveform_editor/shape_editor/plasma_properties.py
@@ -73,26 +73,30 @@ class PlasmaProperties(Viewer):
         elif self.input_mode == self.MANUAL_INPUT:
             self._load_properties_from_params()
 
+        # Define kdims/vdims otherwise Holoviews will link axes with flux map
+        kdims = "Normalized Poloidal Flux"
+        vdims = "Profile Value"
+
         if self.has_properties:
             dpressure_dpsi_curve = hv.Curve(
                 (self.psi, self.dpressure_dpsi),
+                kdims=kdims,
+                vdims=vdims,
                 label="dpressure_dpsi",
             )
             f_df_dpsi_curve = hv.Curve(
                 (self.psi, self.f_df_dpsi),
+                kdims=kdims,
+                vdims=vdims,
                 label="f_df_dpsi",
             )
 
             overlay = dpressure_dpsi_curve * f_df_dpsi_curve
         else:
-            overlay = hv.Overlay([hv.Curve([])])
+            overlay = hv.Overlay([hv.Curve([], kdims=kdims, vdims=vdims)])
 
         self.profile_overlay = overlay.opts(
-            hv.opts.Overlay(
-                title="Plasma Profiles",
-                xlabel="Normalized poloidal flux",
-                ylabel="Profile value",
-            ),
+            hv.opts.Overlay(title="Plasma Profiles"),
             hv.opts.Curve(framewise=True),
         )
 

--- a/waveform_editor/shape_editor/plasma_shape.py
+++ b/waveform_editor/shape_editor/plasma_shape.py
@@ -6,7 +6,7 @@ import panel as pn
 import param
 from panel.viewable import Viewer
 
-from waveform_editor.util import EquilibriumInput
+from waveform_editor.util import EquilibriumInput, FormattedEditableFloatSlider
 
 
 class PlasmaShapeParams(param.Parameterized):
@@ -32,11 +32,6 @@ class PlasmaShapeParams(param.Parameterized):
     n_desired_bnd_points = param.Integer(
         default=96, softbounds=[3, 200], label="Number of boundary points"
     )
-
-
-class FormattedEditableFloatSlider(pn.widgets.EditableFloatSlider):
-    def __init__(self, **params):
-        super().__init__(format="1[.]000", **params)
 
 
 class PlasmaShape(Viewer):

--- a/waveform_editor/util.py
+++ b/waveform_editor/util.py
@@ -3,6 +3,7 @@ import io
 
 import imas
 import numpy as np
+import panel as pn
 import param
 
 AVAILABLE_DD_VERSIONS = imas.dd_zip.dd_xml_versions()
@@ -41,6 +42,11 @@ def times_from_csv(source, from_file_path=True):
     # Convert string values to floats
     time_array = [float(value) for value in rows[0]]
     return np.array(time_array)
+
+
+class FormattedEditableFloatSlider(pn.widgets.EditableFloatSlider):
+    def __init__(self, format="1[.]000", **params):
+        super().__init__(format=format, **params)
 
 
 class EquilibriumInput(param.Parameterized):


### PR DESCRIPTION
`PlasmaProperties` now supports manual input. The p' and ff' profiles can be parameterized using alpha, beta, and gamma parameters.

[Screencast from 2025-08-14 15-25-38.webm](https://github.com/user-attachments/assets/27923b8a-72a6-4f9d-b6ea-0d1e3bfd8ff8)
