### PR TITLE
Remove logging.basicConfig from module level

### DIFF
--- a/waveform_editor/cli.py
+++ b/waveform_editor/cli.py
@@ -26,7 +26,7 @@ def _excepthook(type_, value, tb):
 
 @click.group("waveform-editor", invoke_without_command=True, no_args_is_help=True)
 @click.option("--version", is_flag=True, help="Show version information")
-@click.option("-v", "--verbose", is_flag=True, help="Show more verbose output")
+@click.option("-v", "--verbose", count=True, help="Show verbose output")
 def cli(version, verbose):
     """The Waveform Editor command line interface.
 
@@ -35,11 +35,17 @@ def cli(version, verbose):
 
         waveform-editor <command> --help
     """
-    if verbose:
-        logger.setLevel(logging.DEBUG)
-    # Limit the traceback to 1 item: avoid scaring CLI users with long traceback prints
-    # and let them focus on the actual error message
-    sys.excepthook = _excepthook
+    loglevel = logging.WARNING
+    if verbose == 1:
+        loglevel = logging.INFO
+    elif verbose > 1:
+        loglevel = logging.DEBUG
+    logging.basicConfig(level=loglevel)
+
+    if verbose <= 1:
+        # Limit the traceback to 1 item: avoid scaring CLI users with long traceback
+        # prints and let them focus on the actual error message
+        sys.excepthook = _excepthook
 
     if version:
         print_version()

--- a/waveform_editor/exporter.py
+++ b/waveform_editor/exporter.py
@@ -10,7 +10,6 @@ from imas.ids_path import IDSPath
 from waveform_editor.pcssp_exporter import PCSSPExporter
 
 logger = logging.getLogger(__name__)
-logging.basicConfig(level=logging.INFO)
 
 
 class ConfigurationExporter:


### PR DESCRIPTION
Configure logger in the CLI instead.

Default log level is WARNING (INFO and DEBUG log messages are not printed).
With `waveform-editor -v`, the log level is increased to INFO.
With `waveform-editor -vv`, the log level is increased to DEBUG.

Additional `-v` flags do not have any effect (currently)