### PR TITLE
Allow loading ITER MD pf_active

### DIFF
--- a/waveform_editor/shape_editor/coil_currents.py
+++ b/waveform_editor/shape_editor/coil_currents.py
@@ -47,7 +47,7 @@ class CoilCurrents(Viewer):
             checkbox = pn.widgets.Checkbox(value=False, margin=(30, 10, 10, 10))
             slider = pn.widgets.EditableFloatSlider(
                 name=f"{coil.name} Current [{coil_current.metadata.units}]",
-                value=coil_current.data[0],
+                value=coil_current.data[0] if coil_current.data.has_value else 0.0,
                 start=-5e4,
                 end=5e4,
                 disabled=checkbox.param.value.rx.not_(),

--- a/waveform_editor/shape_editor/nice_plotter.py
+++ b/waveform_editor/shape_editor/nice_plotter.py
@@ -3,6 +3,7 @@ import logging
 import holoviews as hv
 import matplotlib
 import matplotlib.pyplot as plt
+import numpy as np
 import panel as pn
 import param
 from imas.ids_toplevel import IDSToplevel
@@ -97,6 +98,7 @@ class NicePlotter(pn.viewable.Viewer):
                 for element in coil.element:
                     rect = element.geometry.rectangle
                     outline = element.geometry.outline
+                    annulus = element.geometry.annulus
                     if rect.has_value:
                         r0 = rect.r - rect.width / 2
                         r1 = rect.r + rect.width / 2
@@ -105,6 +107,16 @@ class NicePlotter(pn.viewable.Viewer):
                         rectangles.append((r0, z0, r1, z1, name))
                     elif outline.has_value:
                         paths.append((outline.r, outline.z, name))
+                    elif annulus.r.has_value:
+                        # Just plot outer radius for now
+                        phi = np.linspace(0, 2 * np.pi, 17)
+                        paths.append(
+                            (
+                                (annulus.r + annulus.radius_outer * np.cos(phi)),
+                                (annulus.z + annulus.radius_outer * np.sin(phi)),
+                                name,
+                            )
+                        )
                     else:
                         logger.warning(
                             f"Coil {name} was skipped, as it does not have a filled "


### PR DESCRIPTION
From the ITER MD entry: `imas:hdf5?path=/work/imas/shared/imasdb/ITER_MD/3/111001/204/`

- Plot outer radius of annular geometries
- Handle missing coil currents

**N.B.** NICE cannot currently handle the annular shapes of the Vertical Stability coils, and will segfault when running from this IDS.