### PR TITLE
Add standalone desktop application

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,8 @@ dependencies = [
     "kaleido", # required for exporting PNG to disk
     "asteval",
     "muscle3",
+    "pywebview[qt]",
+    "pyinstaller",
 ]
 dynamic = ["version"]
 

--- a/waveform_editor/cli.py
+++ b/waveform_editor/cli.py
@@ -74,7 +74,13 @@ def parse_linspace(ctx, param, value):
 @click.option(
     "-p", "--port", type=int, default=0, help="Specify port to host application."
 )
-def launch_gui(file, port):
+@click.option(
+    "--standalone",
+    is_flag=True,
+    default=False,
+    help="Launch as a standalone desktop window using pywebview instead of a browser.",
+)
+def launch_gui(file, port, standalone):
     """Launch the Waveform Editor GUI using Panel.
 
     \b
@@ -85,13 +91,20 @@ def launch_gui(file, port):
     # cases:
     import panel as pn
 
-    from waveform_editor.gui.main import WaveformEditorGui
+    from waveform_editor.gui.main import PanelDesktop, WaveformEditorGui
 
     try:
-        app = WaveformEditorGui()
-        if file is not None:
-            app.load_yaml_from_file(Path(file))
-        pn.serve(app, port=port, threaded=True)
+
+        def create_app():
+            app = WaveformEditorGui()
+            if file is not None:
+                app.load_yaml_from_file(Path(file))
+            return app.__panel__()
+
+        if standalone:
+            PanelDesktop().serve(create_app, port=port)
+        else:
+            pn.serve(create_app, port=port, threaded=True)
     except Exception as e:
         logger.error(f"Failed to launch GUI: {e}")
 

--- a/waveform_editor/gui/main.py
+++ b/waveform_editor/gui/main.py
@@ -1,8 +1,11 @@
 import logging
+import socket
+import threading
 
 import imas
 import panel as pn
 import param
+import webview
 
 import waveform_editor
 from waveform_editor.configuration import WaveformConfiguration
@@ -195,6 +198,43 @@ class WaveformEditorGui(param.Parameterized):
         return self.template.servable()
 
 
-# Allow serving with `panel serve waveform_editor/gui/main.py`
-if "bokeh" in __name__:
-    WaveformEditorGui().serve()
+class PanelDesktop:
+    def __init__(self, title="Waveform Editor", width: int = 1920, height: int = 1080):
+        self.title = title
+        self.width = width
+        self.height = height
+
+    @staticmethod
+    def _find_free_port():
+        """Find a free port on localhost."""
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+            s.bind(("", 0))
+            s.listen(1)
+            port = s.getsockname()[1]
+        return port
+
+    def serve(self, app_factory, port: int = 0):
+        if not port:
+            port = self._find_free_port()
+
+        server_thread = threading.Thread(
+            target=lambda: pn.serve(
+                app_factory,
+                port=port,
+                show=False,
+                autoreload=False,
+            ),
+            daemon=True,
+        )
+        server_thread.start()
+
+        webview.create_window(
+            self.title,
+            f"http://localhost:{port}",
+            resizable=True,
+            fullscreen=False,
+            width=self.width,
+            height=self.height,
+            text_select=True,
+        )
+        webview.start()


### PR DESCRIPTION
This allows the panel app to be rendered in a native desktop application. Currently only works locally.

- [ ] Allow standalone mode to run on SDCC through nomachine.