### PR TITLE
Fix NICE direct mode

### DIFF
--- a/waveform_editor/gui/shape_editor/settings_modal.py
+++ b/waveform_editor/gui/shape_editor/settings_modal.py
@@ -49,10 +49,11 @@ def _form_row(label, widget, warning=None):
 class SettingsModal(Viewer):
     nice_settings = param.ClassSelector(class_=NiceSettings)
 
-    def __init__(self, nice_plotter: NicePlotter, **params):
+    def __init__(self, nice_plotter: NicePlotter, shape_editor, **params):
         super().__init__(**params)
         self.nice_settings = settings.nice
         self.nice_plotter = nice_plotter
+        self._shape_editor = shape_editor
 
         modal = self._build_modal()
         button_icon = pn.widgets.ButtonIcon(
@@ -183,8 +184,45 @@ class SettingsModal(Viewer):
             scroll=True,
         )
 
+        # --- General tab ---
+        self._warm_start_switch = pn.widgets.Switch.from_param(
+            self._shape_editor.param.use_previous_run,
+            name="",
+            disabled=self._shape_editor.communicator.param.can_warm_start.rx.not_(),
+            margin=(15, 0, 0, 0),
+        )
+        no_equilibrium_msg = pn.pane.HTML(
+            '<span class="form-row-label form-row-label--warning">'
+            "No previous equilibrium available, run NICE to enable."
+            "</span>",
+            stylesheets=STYLES,
+            visible=self._shape_editor.communicator.param.can_warm_start.rx.not_(),
+            sizing_mode="stretch_width",
+            margin=(4, 10),
+        )
+        general_content = pn.Column(
+            _section_label("Warm Start"),
+            _settings_section(
+                _form_row(
+                    "Start from previous equilibrium",
+                    self._warm_start_switch,
+                    pn.widgets.TooltipIcon(
+                        value=(
+                            "Use the previous converged equilibrium as the starting "
+                            "point. Disabled when no valid equilibrium is available."
+                        ),
+                        margin=10,
+                    ),
+                ),
+                no_equilibrium_msg,
+            ),
+            sizing_mode="stretch_width",
+            scroll=True,
+        )
+
         self.tabs = pn.Tabs(
             ("Display", display_content),
+            ("General", general_content),
             ("Machine Presets", machine_preset_content),
             ("NICE Configuration", nice_content),
             margin=(20, 20, 0, 20),

--- a/waveform_editor/gui/shape_editor/settings_modal.py
+++ b/waveform_editor/gui/shape_editor/settings_modal.py
@@ -49,11 +49,10 @@ def _form_row(label, widget, warning=None):
 class SettingsModal(Viewer):
     nice_settings = param.ClassSelector(class_=NiceSettings)
 
-    def __init__(self, nice_plotter: NicePlotter, shape_editor, **params):
+    def __init__(self, nice_plotter: NicePlotter, **params):
         super().__init__(**params)
         self.nice_settings = settings.nice
         self.nice_plotter = nice_plotter
-        self._shape_editor = shape_editor
 
         modal = self._build_modal()
         button_icon = pn.widgets.ButtonIcon(
@@ -184,45 +183,8 @@ class SettingsModal(Viewer):
             scroll=True,
         )
 
-        # --- General tab ---
-        self._warm_start_switch = pn.widgets.Switch.from_param(
-            self._shape_editor.param.use_previous_run,
-            name="",
-            disabled=self._shape_editor.communicator.param.can_warm_start.rx.not_(),
-            margin=(15, 0, 0, 0),
-        )
-        no_equilibrium_msg = pn.pane.HTML(
-            '<span class="form-row-label form-row-label--warning">'
-            "No previous equilibrium available, run NICE to enable."
-            "</span>",
-            stylesheets=STYLES,
-            visible=self._shape_editor.communicator.param.can_warm_start.rx.not_(),
-            sizing_mode="stretch_width",
-            margin=(4, 10),
-        )
-        general_content = pn.Column(
-            _section_label("Warm Start"),
-            _settings_section(
-                _form_row(
-                    "Start from previous equilibrium",
-                    self._warm_start_switch,
-                    pn.widgets.TooltipIcon(
-                        value=(
-                            "Use the previous converged equilibrium as the starting "
-                            "point. Disabled when no valid equilibrium is available."
-                        ),
-                        margin=10,
-                    ),
-                ),
-                no_equilibrium_msg,
-            ),
-            sizing_mode="stretch_width",
-            scroll=True,
-        )
-
         self.tabs = pn.Tabs(
             ("Display", display_content),
-            ("General", general_content),
             ("Machine Presets", machine_preset_content),
             ("NICE Configuration", nice_content),
             margin=(20, 20, 0, 20),

--- a/waveform_editor/gui/shape_editor/shape_editor.py
+++ b/waveform_editor/gui/shape_editor/shape_editor.py
@@ -34,6 +34,9 @@ class ShapeEditor(Viewer):
     pf_passive = param.ClassSelector(class_=IDSToplevel)
     wall = param.ClassSelector(class_=IDSToplevel)
     iron_core = param.ClassSelector(class_=IDSToplevel)
+    use_previous_run = param.Boolean(
+        default=False, doc="Use previous run as warm start"
+    )
 
     def __init__(self, main_gui):
         super().__init__()
@@ -44,7 +47,14 @@ class ShapeEditor(Viewer):
             height=200,
             max_width=750,
         )
-        self.communicator = NiceIntegration(self.factory, on_output=self.terminal.write)
+        self.communicator = NiceIntegration(
+            self.factory,
+            on_output=self.terminal.write,
+            on_run_finished=self._on_nice_run_finished,
+        )
+        self.communicator.param.watch(
+            lambda e: setattr(self, "use_previous_run", e.new), ["can_warm_start"]
+        )
         self.plasma_shape = PlasmaShape()
         self.plasma_properties = PlasmaProperties()
         self.coil_currents = CoilCurrents(main_gui)
@@ -100,12 +110,13 @@ class ShapeEditor(Viewer):
             margin=(10, 10, 2, 0),
         )
         nice_mode_radio = nice_mode_toggle(self.nice_settings, margin=(10, 0, 2, 0))
-        settings_modal = SettingsModal(self.nice_plotter)
+        settings_modal = SettingsModal(self.nice_plotter, self)
         buttons = pn.Row(
             nice_mode_radio,
             pn.Spacer(sizing_mode="stretch_width"),
             button_stop,
             button_start,
+            align="center",
         )
 
         self.metrics = Metrics()
@@ -198,6 +209,7 @@ class ShapeEditor(Viewer):
         self.nice_plotter.pf_active = self.pf_active
         self.coil_currents.create_ui(self.pf_active)
         self.nice_settings.md_pf_active.loaded = self.pf_active is not None
+        self.communicator.equilibrium = None
 
     @param.depends("nice_settings.md_pf_passive.uri", watch=True)
     def _load_pf_passive(self):
@@ -205,12 +217,14 @@ class ShapeEditor(Viewer):
             self.nice_settings.md_pf_passive.uri, "pf_passive"
         )
         self.nice_settings.md_pf_passive.loaded = self.pf_passive is not None
+        self.communicator.equilibrium = None
 
     @param.depends("nice_settings.md_wall.uri", watch=True)
     def _load_wall(self):
         self.wall = self._load_slice(self.nice_settings.md_wall.uri, "wall")
         self.nice_plotter.wall = self.wall
         self.nice_settings.md_wall.loaded = self.wall is not None
+        self.communicator.equilibrium = None
 
     @param.depends("nice_settings.md_iron_core.uri", watch=True)
     def _load_iron_core(self):
@@ -218,6 +232,7 @@ class ShapeEditor(Viewer):
             self.nice_settings.md_iron_core.uri, "iron_core"
         )
         self.nice_settings.md_iron_core.loaded = self.iron_core is not None
+        self.communicator.equilibrium = None
 
     def _create_equilibrium(self):
         """Create and initialize an equilibrium IDS.
@@ -261,6 +276,14 @@ class ShapeEditor(Viewer):
         # the DD!
         slice.profiles_1d.psi = self.plasma_properties.psi_norm
 
+    def _on_nice_run_finished(self, success):
+        if success:
+            pn.state.notifications.success("NICE run complete.")
+        else:
+            pn.state.notifications.error(
+                "NICE did not converge. Check the terminal for details."
+            )
+
     async def submit(self, event=None):
         """Submit a new equilibrium reconstruction job to NICE, passing the machine
         description IDSs and an input equilibrium IDS."""
@@ -275,12 +298,23 @@ class ShapeEditor(Viewer):
         # Update XML parameters:
         xml_params.find("verbose").text = str(self.nice_settings.verbose)
 
-        # Load previous equilibrium from communicator output if available
-        if self.communicator.equilibrium is not None:
+        use_previous_equilibrium = (
+            self.use_previous_run and self.communicator.can_warm_start
+        )
+        if use_previous_equilibrium:
+            pn.state.notifications.info("Starting from previous equilibrium.")
             equilibrium = self.communicator.equilibrium
         else:
             equilibrium = self._create_equilibrium()
         self._fill_equilibrium(equilibrium)
+
+        if self.nice_settings.is_direct_mode:
+            start_from_scratch = "0" if use_previous_equilibrium else "1"
+            xml_params.find("algoStartFromScratch").text = start_from_scratch
+            xml_params.find("algoStartFromScratchReconAB").text = start_from_scratch
+            xml_params.find("algoStartPsiFromInData").text = (
+                "1" if use_previous_equilibrium else "0"
+            )
 
         if not self.communicator.running:
             await self.communicator.run(

--- a/waveform_editor/gui/shape_editor/shape_editor.py
+++ b/waveform_editor/gui/shape_editor/shape_editor.py
@@ -109,13 +109,14 @@ class ShapeEditor(Viewer):
         nice_mode_radio = nice_mode_toggle(self.nice_settings, margin=(10, 0, 2, 0))
         warm_start_switch = pn.widgets.Switch.from_param(
             self.param.use_previous_run,
-            name="Warm start",
+            name="",
             disabled=self.communicator.param.can_warm_start.rx.not_(),
-            margin=(16, 15, 2, 10),
+            margin=(20, 15, 2, 10),
         )
         settings_modal = SettingsModal(self.nice_plotter)
         buttons = pn.Row(
             nice_mode_radio,
+            pn.widgets.StaticText(value="Use previous run", margin=(15, 0, 2, 10)),
             warm_start_switch,
             pn.Spacer(sizing_mode="stretch_width"),
             button_stop,

--- a/waveform_editor/gui/shape_editor/shape_editor.py
+++ b/waveform_editor/gui/shape_editor/shape_editor.py
@@ -219,7 +219,7 @@ class ShapeEditor(Viewer):
         )
         self.nice_settings.md_iron_core.loaded = self.iron_core is not None
 
-    def _create_equilibrium(self):
+    def _create_empty_equilibrium(self):
         """Create an empty equilibrium IDS and fill the plasma shape parameters and
         plasma properties.
 
@@ -234,6 +234,9 @@ class ShapeEditor(Viewer):
         equilibrium.time_slice.resize(1)
         equilibrium.vacuum_toroidal_field.b0.resize(1)
 
+        return equilibrium
+
+    def _fill_equilibrium(self, equilibrium):
         # Only fill plasma shape for NICE inverse mode
         if self.nice_settings.is_inverse_mode:
             equilibrium.time_slice[0].boundary.outline.r = self.plasma_shape.outline_r
@@ -253,7 +256,6 @@ class ShapeEditor(Viewer):
         # N.B. We fill psi with psi_norm. This works for NICE, but is not adhering to
         # the DD!
         slice.profiles_1d.psi = self.plasma_properties.psi_norm
-        return equilibrium
 
     async def submit(self, event=None):
         """Submit a new equilibrium reconstruction job to NICE, passing the machine
@@ -268,7 +270,14 @@ class ShapeEditor(Viewer):
 
         # Update XML parameters:
         xml_params.find("verbose").text = str(self.nice_settings.verbose)
-        equilibrium = self._create_equilibrium()
+
+        # Use previous equilibrium from communicator output if available
+        if self.communicator.equilibrium is not None:
+            equilibrium = self.communicator.equilibrium
+        else:
+            equilibrium = self._create_empty_equilibrium()
+        self._fill_equilibrium(equilibrium)
+
         if not self.communicator.running:
             await self.communicator.run(
                 is_direct_mode=self.nice_settings.is_direct_mode

--- a/waveform_editor/gui/shape_editor/shape_editor.py
+++ b/waveform_editor/gui/shape_editor/shape_editor.py
@@ -113,11 +113,28 @@ class ShapeEditor(Viewer):
             disabled=self.communicator.param.can_warm_start.rx.not_(),
             margin=(20, 15, 2, 10),
         )
+        tooltip_msg = (
+            "Enable warm start to use the previous run's equilibrium as the "
+            "initial guess for the next run. This can improve convergence."
+        )
+        warm_start_tooltip = pn.widgets.TooltipIcon(
+            value=pn.bind(
+                lambda can: (
+                    tooltip_msg
+                    if can
+                    else f"{tooltip_msg}\n\nNo previous run is available yet. "
+                    "Run NICE once to allow warm starting. "
+                ),
+                self.communicator.param.can_warm_start,
+            ),
+            margin=(5, 0, 2, 0),
+        )
         settings_modal = SettingsModal(self.nice_plotter)
         buttons = pn.Row(
             nice_mode_radio,
-            pn.widgets.StaticText(value="Use previous run", margin=(15, 0, 2, 10)),
+            pn.widgets.StaticText(value="Warm start", margin=(15, 0, 2, 10)),
             warm_start_switch,
+            warm_start_tooltip,
             pn.Spacer(sizing_mode="stretch_width"),
             button_stop,
             button_start,
@@ -206,6 +223,17 @@ class ShapeEditor(Viewer):
             except Exception as e:
                 pn.state.notifications.error(str(e))
 
+    @param.depends(
+        "nice_settings.md_pf_active.uri",
+        "nice_settings.md_pf_passive.uri",
+        "nice_settings.md_wall.uri",
+        "nice_settings.md_iron_core.uri",
+        watch=True,
+    )
+    def _disable_warm_start(self):
+        self.use_previous_run = False
+        self.communicator.can_warm_start = False
+
     @param.depends("nice_settings.md_pf_active.uri", watch=True)
     def _load_pf_active(self):
         self.pf_active = self._load_slice(
@@ -214,7 +242,6 @@ class ShapeEditor(Viewer):
         self.nice_plotter.pf_active = self.pf_active
         self.coil_currents.create_ui(self.pf_active)
         self.nice_settings.md_pf_active.loaded = self.pf_active is not None
-        self.communicator.can_warm_start = False
 
     @param.depends("nice_settings.md_pf_passive.uri", watch=True)
     def _load_pf_passive(self):
@@ -222,14 +249,12 @@ class ShapeEditor(Viewer):
             self.nice_settings.md_pf_passive.uri, "pf_passive"
         )
         self.nice_settings.md_pf_passive.loaded = self.pf_passive is not None
-        self.communicator.can_warm_start = False
 
     @param.depends("nice_settings.md_wall.uri", watch=True)
     def _load_wall(self):
         self.wall = self._load_slice(self.nice_settings.md_wall.uri, "wall")
         self.nice_plotter.wall = self.wall
         self.nice_settings.md_wall.loaded = self.wall is not None
-        self.communicator.can_warm_start = False
 
     @param.depends("nice_settings.md_iron_core.uri", watch=True)
     def _load_iron_core(self):
@@ -237,7 +262,6 @@ class ShapeEditor(Viewer):
             self.nice_settings.md_iron_core.uri, "iron_core"
         )
         self.nice_settings.md_iron_core.loaded = self.iron_core is not None
-        self.communicator.can_warm_start = False
 
     def _create_equilibrium(self):
         """Create and initialize an equilibrium IDS.

--- a/waveform_editor/gui/shape_editor/shape_editor.py
+++ b/waveform_editor/gui/shape_editor/shape_editor.py
@@ -219,12 +219,11 @@ class ShapeEditor(Viewer):
         )
         self.nice_settings.md_iron_core.loaded = self.iron_core is not None
 
-    def _create_empty_equilibrium(self):
-        """Create an empty equilibrium IDS and fill the plasma shape parameters and
-        plasma properties.
+    def _create_equilibrium(self):
+        """Create and initialize an equilibrium IDS.
 
         Returns:
-            The filled equilibrium IDS
+            The equilibrium IDS
         """
         equilibrium = self.factory.new("equilibrium")
         equilibrium.ids_properties.homogeneous_time = (
@@ -237,6 +236,11 @@ class ShapeEditor(Viewer):
         return equilibrium
 
     def _fill_equilibrium(self, equilibrium):
+        """Fill equilibrium IDS with plasma boundary and core profiles.
+
+        Args:
+            equilibrium: equilibrium IDS object to fill
+        """
         # Only fill plasma shape for NICE inverse mode
         if self.nice_settings.is_inverse_mode:
             equilibrium.time_slice[0].boundary.outline.r = self.plasma_shape.outline_r
@@ -271,11 +275,11 @@ class ShapeEditor(Viewer):
         # Update XML parameters:
         xml_params.find("verbose").text = str(self.nice_settings.verbose)
 
-        # Use previous equilibrium from communicator output if available
+        # Load previous equilibrium from communicator output if available
         if self.communicator.equilibrium is not None:
             equilibrium = self.communicator.equilibrium
         else:
-            equilibrium = self._create_empty_equilibrium()
+            equilibrium = self._create_equilibrium()
         self._fill_equilibrium(equilibrium)
 
         if not self.communicator.running:

--- a/waveform_editor/gui/shape_editor/shape_editor.py
+++ b/waveform_editor/gui/shape_editor/shape_editor.py
@@ -52,9 +52,6 @@ class ShapeEditor(Viewer):
             on_output=self.terminal.write,
             on_run_finished=self._on_nice_run_finished,
         )
-        self.communicator.param.watch(
-            lambda e: setattr(self, "use_previous_run", e.new), ["can_warm_start"]
-        )
         self.plasma_shape = PlasmaShape()
         self.plasma_properties = PlasmaProperties()
         self.coil_currents = CoilCurrents(main_gui)
@@ -110,9 +107,16 @@ class ShapeEditor(Viewer):
             margin=(10, 10, 2, 0),
         )
         nice_mode_radio = nice_mode_toggle(self.nice_settings, margin=(10, 0, 2, 0))
-        settings_modal = SettingsModal(self.nice_plotter, self)
+        warm_start_switch = pn.widgets.Switch.from_param(
+            self.param.use_previous_run,
+            name="Warm start",
+            disabled=self.communicator.param.can_warm_start.rx.not_(),
+            margin=(16, 15, 2, 10),
+        )
+        settings_modal = SettingsModal(self.nice_plotter)
         buttons = pn.Row(
             nice_mode_radio,
+            warm_start_switch,
             pn.Spacer(sizing_mode="stretch_width"),
             button_stop,
             button_start,
@@ -209,7 +213,7 @@ class ShapeEditor(Viewer):
         self.nice_plotter.pf_active = self.pf_active
         self.coil_currents.create_ui(self.pf_active)
         self.nice_settings.md_pf_active.loaded = self.pf_active is not None
-        self.communicator.equilibrium = None
+        self.communicator.can_warm_start = False
 
     @param.depends("nice_settings.md_pf_passive.uri", watch=True)
     def _load_pf_passive(self):
@@ -217,14 +221,14 @@ class ShapeEditor(Viewer):
             self.nice_settings.md_pf_passive.uri, "pf_passive"
         )
         self.nice_settings.md_pf_passive.loaded = self.pf_passive is not None
-        self.communicator.equilibrium = None
+        self.communicator.can_warm_start = False
 
     @param.depends("nice_settings.md_wall.uri", watch=True)
     def _load_wall(self):
         self.wall = self._load_slice(self.nice_settings.md_wall.uri, "wall")
         self.nice_plotter.wall = self.wall
         self.nice_settings.md_wall.loaded = self.wall is not None
-        self.communicator.equilibrium = None
+        self.communicator.can_warm_start = False
 
     @param.depends("nice_settings.md_iron_core.uri", watch=True)
     def _load_iron_core(self):
@@ -232,7 +236,7 @@ class ShapeEditor(Viewer):
             self.nice_settings.md_iron_core.uri, "iron_core"
         )
         self.nice_settings.md_iron_core.loaded = self.iron_core is not None
-        self.communicator.equilibrium = None
+        self.communicator.can_warm_start = False
 
     def _create_equilibrium(self):
         """Create and initialize an equilibrium IDS.

--- a/waveform_editor/gui/styles/styles.css
+++ b/waveform_editor/gui/styles/styles.css
@@ -39,6 +39,10 @@ a.title, span.title { display: none !important; }
     white-space: nowrap;
 }
 
+.form-row-label--warning {
+    color: var(--warning-color, #856404);
+}
+
 /* Settings modal tabs */
 .bk-tab { flex: 1; text-align: center; }
 

--- a/waveform_editor/shape_editor/nice_integration.py
+++ b/waveform_editor/shape_editor/nice_integration.py
@@ -142,7 +142,6 @@ class NiceIntegration(param.Parameterized):
     pf_active = param.ClassSelector(class_=IDSToplevel)
 
     processing = param.Boolean(doc="NICE is processing an equilibrium")
-    last_run_successful = param.Boolean(default=False)
     can_warm_start = param.Boolean(default=False)
 
     def __init__(
@@ -155,6 +154,7 @@ class NiceIntegration(param.Parameterized):
         self.imas_factory = imas_factory
         self.on_output = on_output
         self.on_run_finished = on_run_finished
+        self.last_run_successful = False
         self.running = False
         self.closing = False
         self.pf_active = None

--- a/waveform_editor/shape_editor/nice_integration.py
+++ b/waveform_editor/shape_editor/nice_integration.py
@@ -142,23 +142,26 @@ class NiceIntegration(param.Parameterized):
     pf_active = param.ClassSelector(class_=IDSToplevel)
 
     processing = param.Boolean(doc="NICE is processing an equilibrium")
+    last_run_successful = param.Boolean(default=False)
+    can_warm_start = param.Boolean(default=False)
 
     def __init__(
         self,
         imas_factory,
-        on_output: Callable[[str | bytes], None] | None = None,
+        on_output: Callable[[str | bytes], None],
+        on_run_finished: Callable[[bool], None],
     ):
         super().__init__()
         self.imas_factory = imas_factory
         self.on_output = on_output
+        self.on_run_finished = on_run_finished
         self.running = False
         self.closing = False
         self.pf_active = None
         self._poll_task = None
 
     def _write_output(self, text: str | bytes):
-        if self.on_output is not None:
-            self.on_output(text)
+        self.on_output(text)
 
     def create_communicator_protocol(self):
         """Instantiate protocol to handle NICE subprocess output."""
@@ -286,10 +289,21 @@ class NiceIntegration(param.Parameterized):
             and self.nice_transport.get_returncode() is None
         )
 
+    @param.depends("equilibrium", watch=True)
+    def _update_can_warm_start(self):
+        if self.equilibrium is None:
+            self.can_warm_start = False
+        else:
+            self.can_warm_start = bool(self.equilibrium.code.output_flag[0] == 0)
+
     @param.depends("nice_running", watch=True)
     async def _nice_running_changed(self):
         if not self.nice_running:  # figure out why:
             retcode = self.nice_transport.get_returncode()
+            self.last_run_successful = retcode == 0
+            if not self.last_run_successful:
+                self.can_warm_start = False
+                self.on_run_finished(False)
             # Bold green on success, bold red on failure:
             color = "\033[32;1m" if retcode == 0 else "\033[31;1m"
             # Add signal description (if relevant), e.g. 'Segmentation fault'
@@ -352,6 +366,7 @@ class NiceIntegration(param.Parameterized):
         pf_active = self.imas_factory.new("pf_active")
         pf_active.deserialize(pfa)
         self.pf_active = pf_active
+        self.on_run_finished(self.can_warm_start)
         self.processing = False
 
 

--- a/waveform_editor/shape_editor/xml_param/direct_param.xml
+++ b/waveform_editor/shape_editor/xml_param/direct_param.xml
@@ -20,9 +20,9 @@
   <algoReconPolar>0</algoReconPolar>
   <algoReconPressure>0</algoReconPressure>
   <algoReconMSE>0</algoReconMSE>
-  <algoStartFromScratch>1</algoStartFromScratch>
-  <algoStartFromScratchReconAB>1</algoStartFromScratchReconAB>
-  <algoStartPsiFromInData>0</algoStartPsiFromInData>
+  <algoStartFromScratch>0</algoStartFromScratch>
+  <algoStartFromScratchReconAB>0</algoStartFromScratchReconAB>
+  <algoStartPsiFromInData>1</algoStartPsiFromInData>
   <algoWithIp>1</algoWithIp>
   <iterMaxDir>40</iterMaxDir>
   <epsStopDir>1.0e-10</epsStopDir>


### PR DESCRIPTION
This uses the equilibrium IDS from a previous run as input for a subsequent run. This allows NICE direct mode to be used with the following workflow:

1. Run NICE inverse mode, setting the desired shape.
2. Run NICE direct mode afterwards, slightly altering the coil currents received from the previous inverse mode run to tweak the plasma shape.