### PR TITLE
Add whole-trace / overlay mode to the MUSCLE3 waveform actor

### DIFF
--- a/docs/source/muscle3.rst
+++ b/docs/source/muscle3.rst
@@ -15,9 +15,22 @@ This page assumes you are familiar with `MUSCLE3 <https://muscle3.readthedocs.io
 Actor details
 -------------
 
-The actor expects messages on a single input port. We take the timestamp of the
-message and evaluate all waveforms at that moment in time. These waveforms are
-stored in their respective IDSs and sent on the respective (connected) output port.
+The actor expects a message on a single input port, evaluates all configured waveforms,
+and sends each resulting IDS on its matching (connected) output port. The **name of the
+input port** selects between two modes:
+
+- **Fresh export** -- when the port name is *not* an IDS name (e.g. ``time_in``). The
+  waveforms are evaluated at the message timestamp into a single new time slice per output
+  IDS. Only the timestamp of the incoming message is used.
+
+- **Overlay** -- when the port name is ``<ids>_in`` (or ``<ids>``, i.e. a valid IDS name).
+  The message must carry that IDS; the actor reads its ``time`` array, evaluates the
+  waveforms on every time present, and overlays them onto the received IDS *in place* --
+  preserving all of its other data -- before sending it on. This lets the actor sit inline
+  in a pipeline and augment an IDS passing through, for example adding a plasma-current
+  waveform to an equilibrium on its way to a solver, rather than emitting a fresh IDS. The
+  actor stops with a ``RuntimeError`` if such a port receives no IDS, or an IDS whose
+  ``time`` array is empty.
 
 .. code-block:: yaml
     :caption: Example ``implementations`` section for running the waveform-editor actor
@@ -36,8 +49,10 @@ Available settings
 Input ports (``F_INIT``)
 ''''''''''''''''''''''''
 
-The actor has one input port. The name can be chosen freely in the workflow yMMSL (see
-example below).
+The actor has exactly one input port, whose name selects the export mode (see
+`Actor details`_): name it ``<ids>_in`` (or ``<ids>``) for *overlay* mode -- the time base
+is read from, and the waveforms overlaid onto, the IDS carried in the message; use any
+other name (e.g. ``time_in``) for *fresh export* at the message timestamp.
 
 The actor will stop with a ``RuntimeError`` when there are no input ports, or when there
 are multiple input ports declared.
@@ -55,12 +70,14 @@ error when the ``waveforms.yaml`` doesn't contain waveforms for either the
 ``ec_launchers`` IDS or the ``nbi`` IDS.
 
 
-Example
--------
+Example: fresh export
+---------------------
 
 The following yMMSL shows an example coupling for a hypothetical ``controller`` actor
-with the waveform-editor actor. N.B. ``__PATH__`` is a placeholder which should be
-replaced with the full path to the files.
+with the waveform-editor actor. The actor's input port is ``time_in`` (not an IDS name),
+so it runs in *fresh export* mode: the ``controller`` drives it with timestamps and gets
+back a single-slice ``ec_launchers`` and ``nbi`` IDS each step. N.B. ``__PATH__`` is a
+placeholder which should be replaced with the full path to the files.
 
 .. literalinclude:: ../../tests/muscle3_integration/coupling.ymmsl.in
     :language: yaml
@@ -71,4 +88,25 @@ The corresponding waveform configuration is shown below:
 .. literalinclude:: ../../tests/muscle3_integration/waveforms.yaml
     :language: yaml
     :caption: waveforms.yaml
+
+
+Example: overlay
+----------------
+
+In *overlay* mode the actor augments an IDS that flows through it. Below, a hypothetical
+``solver`` sends an ``equilibrium`` to the actor and receives it back with the configured
+waveforms (here the plasma current ``ip``) written onto every time slice; all other
+``equilibrium`` data is preserved. The input port ``equilibrium_in`` is what selects
+overlay mode. N.B. ``__PATH__`` is a placeholder which should be replaced with the full
+path to the files.
+
+.. literalinclude:: ../../tests/muscle3_integration/overlay.ymmsl.in
+    :language: yaml
+    :caption: overlay.ymmsl.in
+
+The corresponding waveform configuration is shown below:
+
+.. literalinclude:: ../../tests/muscle3_integration/overlay_waveforms.yaml
+    :language: yaml
+    :caption: overlay_waveforms.yaml
 

--- a/tests/muscle3_integration/.gitignore
+++ b/tests/muscle3_integration/.gitignore
@@ -1,1 +1,2 @@
 coupling.ymmsl
+overlay.ymmsl

--- a/tests/muscle3_integration/overlay.ymmsl.in
+++ b/tests/muscle3_integration/overlay.ymmsl.in
@@ -1,0 +1,44 @@
+ymmsl_version: v0.1
+
+model:
+  name: example_overlay_with_waveform_actor
+
+  components:
+    solver:
+      implementation: solver
+      ports:
+        o_i: equilibrium_out
+        s:
+        - equilibrium_in
+
+    waveform_actor:
+      implementation: waveform_actor
+      ports:
+        # An IDS-named input port selects overlay mode:
+        f_init: equilibrium_in
+        # Name of the output port is "<ids_name>_out":
+        o_f:
+        - equilibrium_out
+
+  conduits:
+    solver.equilibrium_out: waveform_actor.equilibrium_in
+    waveform_actor.equilibrium_out: solver.equilibrium_in
+
+settings:
+  # Mandatory setting for the waveform actor: the waveform configuration:
+  waveform_actor.waveforms: __PATH__/overlay_waveforms.yaml
+
+resources:
+  solver:
+    threads: 1
+  waveform_actor:
+    threads: 1
+
+implementations:
+  solver:
+    executable: python
+    args: __PATH__/overlay_solver.py
+
+  waveform_actor:
+    executable: waveform-editor
+    args: actor

--- a/tests/muscle3_integration/overlay_solver.py
+++ b/tests/muscle3_integration/overlay_solver.py
@@ -1,0 +1,47 @@
+import imas
+import numpy as np
+from libmuscle import Instance, Message
+from ymmsl import Operator
+
+
+def solver():
+    """Dummy solver demonstrating the waveform actor in overlay mode.
+
+    It sends a whole-trace equilibrium and receives it back with the configured
+    waveforms (the plasma current) overlaid onto its time slices, its other data kept.
+    """
+    instance = Instance(
+        ports={
+            Operator.O_I: ["equilibrium_out"],
+            Operator.S: ["equilibrium_in"],
+        }
+    )
+
+    factory = imas.IDSFactory("4.0.0")
+
+    while instance.reuse_instance():
+        # Build an equilibrium carrying pre-existing data (a boundary outline):
+        equilibrium = factory.new("equilibrium")
+        equilibrium.ids_properties.homogeneous_time = (
+            imas.ids_defs.IDS_TIME_MODE_HOMOGENEOUS
+        )
+        times = np.linspace(0, 100, 11)
+        equilibrium.time = times
+        equilibrium.time_slice.resize(len(times))
+        for time_slice in equilibrium.time_slice:
+            time_slice.boundary.outline.r = [4.0, 6.0, 8.0]
+        instance.send(
+            "equilibrium_out", Message(times[0], data=equilibrium.serialize())
+        )
+
+        # Receive the equilibrium with ip overlaid on its /time and the rest preserved:
+        msg = instance.receive("equilibrium_in")
+        result = factory.new("equilibrium")
+        result.deserialize(msg.data)
+        assert len(result.time_slice) == len(times)
+        assert result.time_slice[-1].global_quantities.ip == -15e6
+        assert np.array_equal(result.time_slice[0].boundary.outline.r, [4.0, 6.0, 8.0])
+
+
+if __name__ == "__main__":
+    solver()

--- a/tests/muscle3_integration/overlay_waveforms.yaml
+++ b/tests/muscle3_integration/overlay_waveforms.yaml
@@ -1,0 +1,8 @@
+# Waveform configuration for the overlay example: a single plasma-current ramp that the
+# actor writes onto every time slice of the equilibrium it receives.
+globals:
+  dd_version: 4.0.0
+
+Plasma current:
+  equilibrium/time_slice/global_quantities/ip:
+    - {type: linear, to: -15e6, duration: 100}

--- a/tests/muscle3_integration/test_muscle3_integration.py
+++ b/tests/muscle3_integration/test_muscle3_integration.py
@@ -7,11 +7,11 @@ pytest.importorskip("libmuscle")
 pytest.importorskip("imas_core")
 
 
-def test_muscle3_integration(tmp_path, monkeypatch):
+def _run_coupling(tmp_path, name):
     # Prepare yMMSL file:
     curpath = Path(__file__).parent
-    ymmsl_in = curpath / "coupling.ymmsl.in"
-    ymmsl_out = curpath / "coupling.ymmsl"
+    ymmsl_in = curpath / f"{name}.ymmsl.in"
+    ymmsl_out = curpath / f"{name}.ymmsl"
     ymmsl_out.write_text(ymmsl_in.read_text().replace("__PATH__", str(curpath)))
 
     # Start workflow and check that it completes successfully
@@ -20,3 +20,13 @@ def test_muscle3_integration(tmp_path, monkeypatch):
         cwd=tmp_path,
         check=True,
     )
+
+
+def test_muscle3_integration(tmp_path):
+    """Fresh-export mode: the actor is driven with timestamps."""
+    _run_coupling(tmp_path, "coupling")
+
+
+def test_muscle3_overlay_integration(tmp_path):
+    """Overlay mode: the actor augments an equilibrium flowing through it."""
+    _run_coupling(tmp_path, "overlay")

--- a/tests/test_exporter.py
+++ b/tests/test_exporter.py
@@ -707,3 +707,29 @@ def test_example_yaml(tmp_path):
         nbi.unit[0].power_launched.data == 16.5e6 * (values**2.5) / (870e3**2.5)
     )
     assert np.all(nbi.unit[0].energy.data == values)
+
+
+def test_overlay_base_without_waveforms_warns(caplog):
+    """An overlay base whose IDS has no waveforms in the config is dropped, with a
+    warning, rather than silently passed through."""
+    yaml_str = """
+    equilibrium:
+      equilibrium/time_slice/global_quantities/ip:
+      - {from: 2, to: 3, duration: 1}
+    """
+    config = WaveformConfiguration()
+    config.load_yaml(yaml_str)
+
+    # Provide a 'core_profiles' base that the configuration says nothing about.
+    base = imas.IDSFactory("4.0.0").new("core_profiles")
+    exporter = ConfigurationExporter(
+        config, np.array([0.0, 1.0]), base_idss={"core_profiles": base}
+    )
+
+    with caplog.at_level("WARNING"):
+        idss = exporter.to_ids_dict()
+
+    assert "core_profiles" not in idss  # dropped, not passed through
+    assert "equilibrium" in idss
+    assert "core_profiles" in caplog.text
+    assert "no waveforms" in caplog.text

--- a/tests/test_muscle3.py
+++ b/tests/test_muscle3.py
@@ -7,7 +7,10 @@ libmuscle = pytest.importorskip("libmuscle")
 ymmsl = pytest.importorskip("ymmsl")
 
 # This cannot be imported if libmuscle is not available
-from waveform_editor.muscle3 import waveform_actor  # noqa: E402
+from waveform_editor.muscle3 import (  # noqa: E402
+    _time_base_and_base_ids,
+    waveform_actor,
+)
 
 # imas_core is required for IDS serialize, unfortunately this means we cannot run these
 # tests in github Actions yet..
@@ -187,3 +190,54 @@ def test_muscle3_whole_trace(tmp_path, monkeypatch):
         "trace_validator": trace_validator,
     }
     libmuscle.runner.run_simulation(configuration, implementations)
+
+
+# --- overlay-mode validation of the incoming base IDS ---------------------------------
+
+
+class _Msg:
+    """Minimal stand-in for a libmuscle Message (only the fields the helper reads)."""
+
+    def __init__(self, data, timestamp=0.0):
+        self.data = data
+        self.timestamp = timestamp
+
+
+def _eq_msg(homogeneous_time, time):
+    eq = imas.IDSFactory("4.0.0").equilibrium()
+    eq.ids_properties.homogeneous_time = homogeneous_time
+    if time is not None:
+        eq.time = time
+    return _Msg(eq.serialize())
+
+
+def test_overlay_non_homogeneous_warns(caplog):
+    """A non-homogeneous base is overlaid but warns; INFO names the selected mode."""
+    msg = _eq_msg(imas.ids_defs.IDS_TIME_MODE_HETEROGENEOUS, TRACE_TIMES)
+    with caplog.at_level("INFO"):
+        times, base_idss = _time_base_and_base_ids(msg, "equilibrium_in", "4.0.0")
+    assert np.array_equal(times, TRACE_TIMES)
+    assert set(base_idss) == {"equilibrium"}
+    assert "overlay mode" in caplog.text
+    assert "homogeneous time mode" in caplog.text
+
+
+def test_overlay_homogeneous_does_not_warn(caplog):
+    msg = _eq_msg(imas.ids_defs.IDS_TIME_MODE_HOMOGENEOUS, TRACE_TIMES)
+    with caplog.at_level("WARNING"):
+        _time_base_and_base_ids(msg, "equilibrium_in", "4.0.0")
+    assert "homogeneous time mode" not in caplog.text
+
+
+def test_overlay_missing_time_raises():
+    msg = _eq_msg(imas.ids_defs.IDS_TIME_MODE_HOMOGENEOUS, None)
+    with pytest.raises(RuntimeError, match="no root '/time'"):
+        _time_base_and_base_ids(msg, "equilibrium_in", "4.0.0")
+
+
+def test_fresh_export_mode(caplog):
+    """A port whose name is not a valid IDS selects fresh-export mode."""
+    with caplog.at_level("INFO"):
+        times, base_idss = _time_base_and_base_ids(_Msg(None, 3.0), "input", "4.0.0")
+    assert np.array_equal(times, [3.0]) and base_idss == {}
+    assert "fresh-export mode" in caplog.text

--- a/tests/test_muscle3.py
+++ b/tests/test_muscle3.py
@@ -98,3 +98,92 @@ def test_muscle3(tmp_path, monkeypatch):
         "waveform_validator": waveform_validator,
     }
     libmuscle.runner.run_simulation(configuration, implementations)
+
+
+# --- whole-trace mode: an '<ids>_in' port carrying an IDS -> overlay on its /time ----
+
+TRACE_YAML = """
+equilibrium:
+  equilibrium/time_slice/global_quantities/ip:
+    - {to: 8.33e5, duration: 20}
+    - {type: constant, duration: 20}
+    - {duration: 25, to: 0}
+globals:
+  dd_version: 4.0.0
+"""
+# Same waveform as the per-slice test, but now interpolated onto a whole trace at once:
+TRACE_TIMES = [1.0, 21.0, 50.0]
+TRACE_IP = [8.33e5 / 20, 8.33e5, 8.33e5 * 15 / 25]
+BOUNDARY_R = [4.0, 5.0, 6.0]  # pre-existing data the overlay must preserve
+
+TRACE_YMMSL = """
+ymmsl_version: v0.1
+
+model:
+  name: test_waveform_actor_trace
+
+  components:
+    trace_generator:
+      implementation: trace_generator
+    waveform_actor:
+      implementation: waveform_actor
+    trace_validator:
+      implementation: trace_validator
+
+  conduits:
+    trace_generator.output: waveform_actor.equilibrium_in
+    waveform_actor.equilibrium_out: trace_validator.equilibrium_in
+
+settings:
+  waveform_actor.waveforms: {waveform_yaml}
+"""
+
+
+def trace_generator():
+    instance = libmuscle.Instance({ymmsl.Operator.O_I: ["output"]})
+
+    while instance.reuse_instance():
+        # Send a whole-trace equilibrium with pre-existing data (a boundary outline);
+        # the actor reads /time, overlays Ip, and must preserve the rest in place.
+        eq = imas.IDSFactory("4.0.0").equilibrium()
+        eq.ids_properties.homogeneous_time = imas.ids_defs.IDS_TIME_MODE_HOMOGENEOUS
+        eq.time = TRACE_TIMES
+        eq.time_slice.resize(len(TRACE_TIMES))
+        for ts in eq.time_slice:
+            ts.boundary.outline.r = BOUNDARY_R
+        instance.send("output", libmuscle.Message(TRACE_TIMES[0], data=eq.serialize()))
+
+
+def trace_validator():
+    instance = libmuscle.Instance({ymmsl.Operator.F_INIT: ["equilibrium_in"]})
+
+    i = 0
+    while instance.reuse_instance():
+        msg = instance.receive("equilibrium_in")
+        ids = imas.IDSFactory("4.0.0").equilibrium()
+        ids.deserialize(msg.data)
+
+        # A single message now carries the full trace interpolated on the input /time:
+        assert np.array_equal(ids.time, TRACE_TIMES)
+        assert len(ids.time_slice) == len(TRACE_TIMES)
+        ip = [ts.global_quantities.ip for ts in ids.time_slice]
+        assert np.allclose(ip, TRACE_IP)
+        # ... and the incoming IDS' other data is preserved (overlay, not replace):
+        for ts in ids.time_slice:
+            assert np.array_equal(ts.boundary.outline.r, BOUNDARY_R)
+        i += 1
+    assert i == 1
+
+
+@pytest.mark.filterwarnings("ignore:.*use of fork():DeprecationWarning")
+def test_muscle3_whole_trace(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    waveform_yaml = (tmp_path / "trace.yml").resolve()
+    waveform_yaml.write_text(TRACE_YAML)
+    configuration = ymmsl.load(TRACE_YMMSL.format(waveform_yaml=waveform_yaml))
+    implementations = {
+        "trace_generator": trace_generator,
+        "waveform_actor": waveform_actor,
+        "trace_validator": trace_validator,
+    }
+    libmuscle.runner.run_simulation(configuration, implementations)

--- a/waveform_editor/export/exporter.py
+++ b/waveform_editor/export/exporter.py
@@ -13,10 +13,13 @@ logger = logging.getLogger(__name__)
 
 
 class ConfigurationExporter:
-    def __init__(self, config, times, progress=None):
+    def __init__(self, config, times, progress=None, base_idss=None):
         self.config = config
         self.times = times
         self.progress = progress
+        # {ids_name: IDS} bases to overlay the waveforms onto in place (preserving their
+        # other data), taking precedence over the machine description / an empty IDS.
+        self.base_idss = base_idss or {}
         self.total_progress = None
         self.current_progress = None
         # We assume that all DD times are in seconds
@@ -70,15 +73,7 @@ class ConfigurationExporter:
         self.current_progress = 0
         for ids_name, waveforms in ids_map.items():
             logger.debug(f"Filling {ids_name}...")
-
-            # Copy machine description if provided, otherwise start from empty IDS
-            md = self.config.globals.machine_description.get(ids_name)
-            if md:
-                with imas.DBEntry(md, "r") as entry_md:
-                    orig_ids = entry_md.get(ids_name, autoconvert=False)
-                    ids = imas.convert_ids(orig_ids, self.config.globals.dd_version)
-            else:
-                ids = factory.new(ids_name)
+            ids = self._base_ids(ids_name, factory)
             # TODO: currently only IDSs with homogeneous time mode are supported
             ids.ids_properties.homogeneous_time = (
                 imas.ids_defs.IDS_TIME_MODE_HOMOGENEOUS
@@ -86,6 +81,18 @@ class ConfigurationExporter:
             ids.time = self.times
             self._fill_waveforms(ids, waveforms)
             yield ids_name, ids
+
+    def _base_ids(self, ids_name, factory):
+        """The IDS to fill the waveforms onto: a caller-provided base, else the machine
+        description, else a new empty IDS."""
+        if ids_name in self.base_idss:
+            return self.base_idss[ids_name]
+        md = self.config.globals.machine_description.get(ids_name)
+        if md:
+            with imas.DBEntry(md, "r") as entry_md:
+                orig_ids = entry_md.get(ids_name, autoconvert=False)
+                return imas.convert_ids(orig_ids, self.config.globals.dd_version)
+        return factory.new(ids_name)
 
     def to_png(self, dir_path):
         """Export the waveforms to PNGs.

--- a/waveform_editor/export/exporter.py
+++ b/waveform_editor/export/exporter.py
@@ -69,6 +69,12 @@ class ConfigurationExporter:
             factory: IDSFactory to use for creating new IDSs
         """
         ids_map = self._get_ids_map()
+        # An overlay base with no waveforms in the config is never filled nor yielded.
+        for ids_name in self.base_idss.keys() - ids_map.keys():
+            logger.warning(
+                f"overlay base '{ids_name}' has no waveforms in the config, "
+                f"so it is not exported."
+            )
         self.total_progress = sum(2 * len(waveforms) for waveforms in ids_map.values())
         self.current_progress = 0
         for ids_name, waveforms in ids_map.items():

--- a/waveform_editor/muscle3.py
+++ b/waveform_editor/muscle3.py
@@ -27,8 +27,10 @@ def _time_base_and_base_ids(msg, input_port, dd_version):
     name = input_port.removesuffix("_in")
     factory = imas.IDSFactory(dd_version)
     if not factory.exists(name):
+        logger.info("fresh-export mode on '%s' (not an IDS name)", input_port)
         return np.array([msg.timestamp]), {}
 
+    logger.info("overlay mode on '%s': overlaying onto '%s'", input_port, name)
     if msg.data is None:
         raise RuntimeError(
             f"input port '{input_port}' selects overlay mode, but the message carried "
@@ -36,9 +38,17 @@ def _time_base_and_base_ids(msg, input_port, dd_version):
         )
     base = factory.new(name)
     base.deserialize(msg.data)
+
+    # Overlay evaluates the waveforms on '/time' and writes the result back homogeneous,
+    # so '/time' is not authoritative for a non-homogeneous base: warn rather than fail.
+    if int(base.ids_properties.homogeneous_time) != (
+        imas.ids_defs.IDS_TIME_MODE_HOMOGENEOUS
+    ):
+        logger.warning("received '%s' IDS is not in homogeneous time mode", name)
+
     times = np.asarray(base.time, dtype=float)
     if times.size == 0:
-        raise RuntimeError(f"received '{name}' IDS has an empty time array")
+        raise RuntimeError(f"received '{name}' IDS has no root '/time' to overlay onto")
     return times, {name: base}
 
 

--- a/waveform_editor/muscle3.py
+++ b/waveform_editor/muscle3.py
@@ -1,6 +1,7 @@
 import logging
 from pathlib import Path
 
+import imas
 import numpy as np
 
 # N.B. libmuscle is an optional dependency
@@ -14,13 +15,41 @@ from waveform_editor.export.exporter import ConfigurationExporter
 logger = logging.getLogger(__name__)
 
 
+def _time_base_and_base_ids(msg, input_port, dd_version):
+    """Resolve the export time base and the optional base IDS to overlay onto.
+
+    The input port name selects the mode. A port named ``<ids>_in`` (a valid IDS name)
+    selects *overlay*: the message must carry that IDS, and the waveforms are evaluated
+    on its ``time`` array and overlaid onto it in place, preserving its other data so it
+    can be passed on (e.g. adding Ip to an equilibrium). Any other name selects *fresh
+    export*: the waveforms are evaluated at ``msg.timestamp`` into a single slice.
+    """
+    name = input_port.removesuffix("_in")
+    factory = imas.IDSFactory(dd_version)
+    if not factory.exists(name):
+        return np.array([msg.timestamp]), {}
+
+    if msg.data is None:
+        raise RuntimeError(
+            f"input port '{input_port}' selects overlay mode, but the message carried "
+            f"no '{name}' IDS"
+        )
+    base = factory.new(name)
+    base.deserialize(msg.data)
+    times = np.asarray(base.time, dtype=float)
+    if times.size == 0:
+        raise RuntimeError(f"received '{name}' IDS has an empty time array")
+    return times, {name: base}
+
+
 def waveform_actor():
     logger.info("Starting waveform actor")
 
-    # N.B. we don't specify our port names, ports are created by libmuscle based on the
-    # conduits specified in the yMMSL file.
-    # - We require exactly one input port for which we only use the timestamp
-    # - Output port names must be '<ids_name>_out' or '<ids_name>'
+    # Ports are created by libmuscle from the yMMSL conduits, not named here.
+    # - Exactly one input port. If named '<ids>_in' and the message carries that IDS,
+    #   the waveforms are exported on its /time and overlaid onto it; otherwise a single
+    #   slice at the message timestamp is exported.
+    # - Output port names must be '<ids>_out' or '<ids>'.
     instance = Instance(flags=InstanceFlags.KEEPS_NO_STATE_FOR_NEXT_USE)
 
     # Settings
@@ -43,7 +72,10 @@ def waveform_actor():
         input_port = ports[Operator.F_INIT][0]
         msg = instance.receive(input_port)
 
-        exporter = ConfigurationExporter(config, np.array([msg.timestamp]))
+        times, base_idss = _time_base_and_base_ids(
+            msg, input_port, config.globals.dd_version
+        )
+        exporter = ConfigurationExporter(config, times, base_idss=base_idss)
         idss = exporter.to_ids_dict()
 
         for portname in ports[Operator.O_F]:


### PR DESCRIPTION
Previously the actor exported a single time slice per reuse at the incoming message timestamp. Now, when the input port is named '<ids>_in' and the F_INIT message carries that IDS, the actor reads its /time and exports the waveforms interpolated onto every time present, in one message -- falling back to the message timestamp otherwise.

The incoming IDS is also used as the export base (new `base_idss` on ConfigurationExporter, sharing the machine-description resolution path), so its existing data is preserved and the waveforms are overlaid in place. This lets the actor sit inline in a pipeline and augment an IDS passing through -- e.g. adding Ip to an equilibrium on its way to a solver -- rather than emitting a fresh IDS.

Both modes are covered by test_muscle3.